### PR TITLE
Fix for paper (clement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ iHam (“interactive HOG Analysis Method’) is an interactive javascript tool b
 
 The iHam library can be directly load using the following link to the latest release:
 
-  <!-- Load the javascript -->
-  <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
+    <!-- Load the javascript -->
+    <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
 
-  <!-- Load the stylesheet -->
-  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css"/>
+    <!-- Load the stylesheet -->
+    <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css"/>
 
 ## For developers: installing iHam as javascript library
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
 # iHam
 
-iHam (“interactive HOG Analysis Method’) is an interactive javascript tool based on the [TnT library](tntvis.github.io/tnt) to visualise the evolutionary history of a specific gene family (HOGs). It is used in the [OMA browser](http://omabrowser.org) and merely requires as input HOGs in the standard OrthoXML format (Schmitt et al. 2011), the underlying species tree in newick format and gene family information in JSON format (see below for examples).
+iHam (“interactive HOG Analysis Method’) is an interactive javascript tool based on the [TnT library](tntvis.github.io/tnt) to visualise the evolutionary history of a specific gene family (HOGs). The viewer is composed of two panels: a species tree which lets the user select a node to focus on a particular taxonomic range of interest, and a matrix that organizes extant genes according to their membership in species (rows) and hierarchical orthologous groups (columns). The tree-guided matrix representation of HOGs facilitates: (i) to delineate orthologous groups at given taxonomic ranges, (ii) to identify duplication and loss events in the species tree, (iii) gauge the cumulative effect of duplication and losses on gene repertoires, and to (iv) identify likely mistakes in genome assembly, annotation, or orthology inference. Users can customize the view in different ways. They can color genes according to protein length or GC-content. Low-confidence HOGs can be masked. Irrelevant clades of species can be collapsed. iHam is a reusable web widget that can be easily embedded into a website, for instance it is used to display HOGs in OMA (http://omabrowser.org; Altenhoff et al. 2018). It merely requires as input HOGs in the standard OrthoXML format (Schmitt et al. 2011), the underlying species tree in newick format and gene family information in JSON format (see below for examples).
 
 
 ## Installation
 
-It can be installed using _yarn_ or _npm_:
+The iHam library can be directly load using the following link to the latest release: (easy embedding)
+  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" />
+  <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
+
+or can be installed using _yarn_ or _npm_: (for javascript developers)
 
     $ npm install --save iham
     $ yarn add iham
@@ -14,11 +18,21 @@ And build using
 
     $ npm run build && npm run build-css
 
-It is also possible to link directly to the latest release:
 
+## iHam dependencies
 
-    <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" />
-    <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
+iHam requires the following javascript libraries loaded to run:
+
+    <!-- d3 -->
+    <script src="https://d3js.org/d3.v3.js"></script>
+
+    <!-- TnT -->
+    <link rel="stylesheet" href="http://tntvis.github.io/tnt/build/tnt.css" type="text/css"/>
+    <script src="http://tntvis.github.io/tnt/build/tnt.js" charset="utf-8"></script>
+
+    <!-- TnT Tooltip-->
+    <link rel="stylesheet" href="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.css" type="text/css"/>
+    <script src="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.min.js" charset="utf-8"></script>
 
 ## Usage
 
@@ -35,7 +49,8 @@ See below for a description of each method. The above snippet, assumes that the 
 
 ## Example
 
-[See this example](http://bl.ocks.org/emepyc/ce259dd519f6a60d35d04c78b40ec425).
+We provide the following example to demonstrate how to embed an iHam session [See this example](http://bl.ocks.org/emepyc/ce259dd519f6a60d35d04c78b40ec425).
+We built for this example a custom options bar that demonstrate how to use iHam options and events API to display supplementary information (e.g. gene coloring based on sequence length) and add new features (e.g. hide low coverage HOGs).
 
 
 # Configuration

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ iHam (“interactive HOG Analysis Method’) is an interactive javascript tool b
 
 ## Installation
 
-The iHam library can be directly load using the following link to the latest release: (easy embedding)
-  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" />
+The iHam library can be directly load using the following link to the latest release:
+
+  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css"/>
   <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
 
-or can be installed using _yarn_ or _npm_: (for javascript developers)
+## For developers: installing iHam as javascript library
+
+iHam can be installed using _yarn_ or _npm_:
 
     $ npm install --save iham
     $ yarn add iham

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ iHam (“interactive HOG Analysis Method’) is an interactive javascript tool b
 
 ## Installation
 
-The iHam library can be directly load using the following link to the latest release:
+The iHam library can be directly loaded using the following link to the latest release:
 
     <!-- Load the javascript -->
     <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
@@ -55,9 +55,7 @@ See below for a description of each method. The above snippet, assumes that the 
 
 ## Example
 
-We provide the following example to demonstrate how to embed an iHam session [See this example](http://bl.ocks.org/emepyc/ce259dd519f6a60d35d04c78b40ec425).
-We built for this example a custom options bar that demonstrate how to use iHam options and events API to display supplementary information (e.g. gene coloring based on sequence length) and add new features (e.g. hide low coverage HOGs).
-
+See [See this example](http://bl.ocks.org/emepyc/ce259dd519f6a60d35d04c78b40ec425) in this repository demonstrating how to use some of the widget options and API calls, like colouring the genes based on sequence length or hiding low coverage HOGs.
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@ iHam (“interactive HOG Analysis Method’) is an interactive javascript tool b
 
 The iHam library can be directly load using the following link to the latest release:
 
-  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css"/>
+  <!-- Load the javascript -->
   <script href="https://dessimozlab.github.io/iHam/iHam.js"></script>
+
+  <!-- Load the stylesheet -->
+  <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css"/>
 
 ## For developers: installing iHam as javascript library
 

--- a/build/iHam.js
+++ b/build/iHam.js
@@ -8218,6 +8218,7 @@ function iHam() {
 
     // Redirection url prefix for tooltip on genes
     // oma_info_url_template: '/cgi-bin/gateway.pl?f=DisplayEntry&amp;p1=',
+    show_oma_link: false,
 
     // text div id
     // current_level_id: 'current_level_text',
@@ -8320,7 +8321,6 @@ function iHam() {
       var limit = 30;
       var data = node.data();
       if (node.is_collapsed()) {
-        // clement - collapsed taxa display '[Collapsed taxa]' + 'name' now. 16 is length of '[Coll...]' prefix.
         if (data.name.length > limit - 16) {
           var truncName_col = data.name.substr(0, limit - 19) + "...";
           return '[Collapsed taxa] ' + truncName_col.replace(/_/g, ' ');
@@ -8436,7 +8436,7 @@ function iHam() {
           gene_tooltip.close();
         }
       })).add("hogs", hog_feature).add('hog_groups', hog_group.on('click', function (hog) {
-        hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div);
+        hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div, config.show_oma_link);
       })));
     }
 
@@ -8630,7 +8630,7 @@ module.exports = {
     }
   },
   hog_header_tooltip: {
-    display: function display(hog, taxa_name, div) {
+    display: function display(hog, taxa_name, div, show_oma_link) {
       var obj = {};
       obj.header = hog.name;
       obj.rows = [];
@@ -8638,14 +8638,17 @@ module.exports = {
         value: "Number of genes: " + hog.genes.length
       });
       obj.rows.push({
-        value: "Coverage: " + hog.coverage.toFixed(2) + " %"
+        value: "% species represented: " + hog.coverage.toFixed(2) + " %"
       });
-      obj.rows.push({
-        value: "<a href=\"https://omabrowser.org/oma/hogs/" + hog.protid + "/" + taxa_name.replace(" ", "%20") + "/fasta\" target=\"_blank\">Sequences (Fasta)</a>"
-      });
-      obj.rows.push({
-        value: "<a href=\"https://omabrowser.org/oma/hogs/" + hog.protid + "/" + taxa_name.replace(" ", "%20") + "/\" target=\"_blank\">HOGs tables</a>"
-      });
+      if (show_oma_link) {
+
+        obj.rows.push({
+          value: "<a href=\"https://omabrowser.org/oma/hogs/" + hog.protid + "/" + taxa_name.replace(" ", "%20") + "/fasta\" target=\"_blank\">Sequences (Fasta)</a>"
+        });
+        obj.rows.push({
+          value: "<a href=\"https://omabrowser.org/oma/hogs/" + hog.protid + "/" + taxa_name.replace(" ", "%20") + "/\" target=\"_blank\">HOGs tables</a>"
+        });
+      }
 
       _hog_header_tooltip = tooltip.list().width(120).id('hog_header_tooltip').container(div).call(this, obj);
     },

--- a/build/iHam.js
+++ b/build/iHam.js
@@ -8320,7 +8320,12 @@ function iHam() {
       var limit = 30;
       var data = node.data();
       if (node.is_collapsed()) {
-        return '[' + node.n_hidden() + ' hidden taxa]';
+        // clement - collapsed taxa display '[Collapsed taxa]' + 'name' now. 16 is length of '[Coll...]' prefix.
+        if (data.name.length > limit - 16) {
+          var truncName_col = data.name.substr(0, limit - 19) + "...";
+          return '[Collapsed taxa] ' + truncName_col.replace(/_/g, ' ');
+        }
+        return '[Collapsed taxa] ' + data.name;
       }
       if ((!config.show_internal_labels || !state.highlight_condition(node)) && data.children && data.children.length > 0) {
         return "";

--- a/examples/easy_embedding/data.js
+++ b/examples/easy_embedding/data.js
@@ -1,0 +1,11939 @@
+const data = {
+  "tree": '(("Korarchaeum cryptofilum (strain OPF8)", ("Haloredivivus sp. (strain G17)", "Nanosalina sp. (strain J07AB43)", "Nanosalinarum sp. (strain J07AB56)")"Nanohaloarchaea", ((("Acidilobus saccharovorans (strain DSM 16705 / JCM 18335 / VKM B-2471 / 345-15)", "Caldisphaera lagunensis (strain DSM 15908 / JCM 11604 / IC-154)")"Acidilobales", (("Aeropyrum pernix (strain ATCC 700893 / DSM 11879 / JCM 9820 / NBRC 100138 / K1)", ("Desulfurococcus kamchatkensis (strain DSM 18924 / JCM 16383 / VKM B-2413 / 1221n)", "Desulfurococcus mucosus (strain ATCC 35584 / DSM 2162 / JCM 9187 / O7/1)")"Desulfurococcus", "Ignicoccus hospitalis (strain KIN4/I / DSM 18386 / JCM 14125)", "Ignisphaera aggregans (strain DSM 17230 / JCM 13409 / AQ1.S1)", ("Staphylothermus hellenicus (strain DSM 12710 / JCM 10830 / BK20S6-10-b1 / P8)", "Staphylothermus marinus (strain ATCC 43588 / DSM 3639 / JCM 9404 / F1)")"Staphylothermus", "Thermogladius cellulolyticus (strain 1633)", "Thermosphaera aggregans (strain DSM 11486 / M11TL)")"Desulfurococcaceae", ("Hyperthermus butylicus (strain DSM 5456 / JCM 9403 / PLM1-5)", "Pyrodictium occultum", "Pyrolobus fumarii (strain DSM 11204 / 1A)")"Pyrodictiaceae")"Desulfurococcales", "Fervidicoccus fontis (strain DSM 19380 / JCM 18336 / VKM B-2539 / Kam940)", ("Acidianus hospitalis (strain W1)", ("Metallosphaera cuprina (strain Ar-4)", "Metallosphaera sedula (strain ATCC 51363 / DSM 5348 / JCM 9185 / NBRC 15509 / TH2)")"Metallosphaera", ("Sulfolobus acidocaldarius (strain ATCC 33909 / DSM 639 / JCM 8929 / NBRC 15157 / NCIMB 11770)", ("Sulfolobus islandicus (strain HVE10/4)", "Sulfolobus islandicus (strain L.D.8.5 / Lassen #2)", "Sulfolobus islandicus (strain L.S.2.15 / Lassen #1)", "Sulfolobus islandicus (strain M.14.25 / Kamchatka #1)", "Sulfolobus islandicus (strain M.16.27)", "Sulfolobus islandicus (strain M.16.4 / Kamchatka #3)", "Sulfolobus islandicus (strain REY15A)", "Sulfolobus islandicus (strain Y.G.57.14 / Yellowstone #1)", "Sulfolobus islandicus (strain Y.N.15.51 / Yellowstone #2)")"Sulfolobus islandicus", ("Sulfolobus solfataricus (strain 98/2)", "Sulfolobus solfataricus (strain ATCC 35092 / DSM 1617 / JCM 11322 / P2)")"Sulfolobus solfataricus", "Sulfolobus tokodaii (strain DSM 16993 / JCM 10545 / NBRC 100140 / 7)")"Sulfolobus")"Sulfolobaceae", ("Thermofilum pendens (strain DSM 2475 / Hrk 5)", ("Caldivirga maquilingensis (strain ATCC 700844 / DSM 13496 / JCM 10307 / IC-167)", ("Pyrobaculum aerophilum (strain ATCC 51768 / IM2 / DSM 7523 / JCM 9630 / NBRC 100827)", "Pyrobaculum arsenaticum (strain DSM 13514 / JCM 11321)", "Pyrobaculum calidifontis (strain JCM 11548 / VA1)", "Pyrobaculum islandicum (strain DSM 4184 / JCM 9189 / GEO3)", "Pyrobaculum neutrophilum (strain DSM 2338 / JCM 9278 / V24Sta)", "Pyrobaculum oguniense (strain DSM 13380 / JCM 10595 / TE7)")"Pyrobaculum", ("Thermoproteus tenax (strain ATCC 35583 / DSM 2078 / JCM 9277 / NBRC 100435 / Kra 1)", "Thermoproteus uzoniensis (strain 768-20)")"Thermoproteus", ("Vulcanisaeta distributa (strain DSM 14429 / JCM 11212 / NBRC 100878 / IC-017)", "Vulcanisaeta moutnovskia (strain 768-28)")"Vulcanisaeta")"Thermoproteaceae")"Thermoproteales")"Thermoprotei", "Crenarchaeota archaeon SCGC AAA471-B05")"Crenarchaeota", ((("Archaeoglobus fulgidus (strain ATCC 49558 / VC-16 / DSM 4304 / JCM 9628 / NBRC 100126)", "Archaeoglobus profundus (strain DSM 5631 / JCM 9629 / NBRC 100127 / Av18)", "Archaeoglobus veneficus (strain DSM 11195 / SNP6)")"Archaeoglobus", "Ferroglobus placidus (strain DSM 10642 / AEDII12DO)")"Archaeoglobaceae", (((("Haloarcula hispanica (strain ATCC 33960 / DSM 4426 / JCM 8911 / NBRC 102182 / NCIMB 2187 / VKM B-1755)", "Haloarcula marismortui (strain ATCC 43049 / DSM 3752 / JCM 8966 / VKM B-1809)")"Haloarcula", "Halomicrobium mukohataei (strain ATCC 700874 / DSM 12286 / JCM 9738 / NCIMB 13541)", "Halorhabdus utahensis (strain DSM 12940 / JCM 11049 / AX-2)", ("Natronomonas moolapensis (strain DSM 18674 / JCM 14361 / 8.8.11)", "Natronomonas pharaonis (strain ATCC 35678 / DSM 2160 / CIP 103997 / NBRC 14720 / NCIMB 2260 / Gabara)")"Natronomonas")"Haloarculaceae", ("Halalkalicoccus jeotgali (strain DSM 18796 / CECT 7217 / JCM 14584 / KCTC 4019 / B3)", ("Halobacterium salinarum (strain ATCC 29341 / DSM 671 / R1)", "Halobacterium salinarum (strain ATCC 700922 / JCM 11081 / NRC-1)")"Halobacterium salinarum")"Halobacteriaceae")"Halobacteriales", ((("Haloferax mediterranei (strain ATCC 33500 / DSM 1411 / JCM 8866 / NBRC 14739 / NCIMB 2177 / R-4)", "Haloferax volcanii (strain ATCC 29605 / DSM 3757 / JCM 8879 / NBRC 14742 / NCIMB 2012 / VKM B-1768 / DS2)")"Haloferax", "Halogeometricum borinquense (strain ATCC 700274 / DSM 11551 / JCM 10706 / PR3)", ("Haloquadratum walsbyi (strain DSM 16790 / HBSQ001)", "Haloquadratum walsbyi (strain DSM 16854 / JCM 12705 / C23)")"Haloquadratum walsbyi")"Haloferacaceae", "Halorubrum lacusprofundi (strain ATCC 49239 / DSM 5036 / JCM 8891 / ACAM 34)")"Haloferacales", ("Halopiger xanaduensis (strain DSM 18323 / JCM 14033 / SH-6)", "Haloterrigena turkmenica (strain ATCC 51198 / DSM 5511 / NCIMB 13204 / VKM B-1734)", "Halovivax ruber (strain DSM 18193 / JCM 13892 / XH-70)", ("Natrialba asiatica (strain ATCC 700177 / DSM 12278 / JCM 9576 / FERM P-10747 / NBRC 102637 / 172P1)", "Natrialba magadii (strain ATCC 43099 / DSM 3394 / CIP 104546 / JCM 8861/ NBRC 102185 / NCIMB 2190 / MS3)")"Natrialba", ("Natrinema pellirubrum (strain DSM 15624 / CIP 106293 / JCM 10476 / NCIMB 786 / 157)", "Natrinema sp. (strain J7-2)")"Natrinema", "Natronobacterium gregoryi (strain ATCC 43098 / DSM 3393 / CCM 3738 / CIP 104747 / JCM 8860 / NBRC 102187 / NCIMB 2189 / SP2)")"Natrialbaceae")"Halobacteria", ((("Methanobacterium lacus (strain AL-21)", "Methanobacterium paludis (strain DSM 25820 / JCM 18151 / SWAN1)")"Methanobacterium", ("Methanobrevibacter ruminantium (strain ATCC 35063 / DSM 1093 / JCM 13430 / OCM 146 / M1)", "Methanobrevibacter smithii (strain ATCC 35061 / DSM 861 / OCM 144 / PS)")"Methanobrevibacter", "Methanosphaera stadtmanae (strain ATCC 43021 / DSM 3091 / JCM 11832 / MCB-3)", ("Methanothermobacter marburgensis (strain ATCC BAA-927 / DSM 2133 / JCM 14651 / NBRC 100331 / OCM 82 / Marburg)", "Methanothermobacter thermautotrophicus (strain ATCC 29096 / DSM 1053 / JCM 10044 / NBRC 100330 / Delta H)")"Methanothermobacter")"Methanobacteriaceae", "Methanothermus fervidus (strain ATCC 43054 / DSM 2088 / JCM 10308 / V24 S)")"Methanobacteriales", ((("Methanocaldococcus fervens (strain DSM 4213 / JCM 15782 / AG86)", "Methanocaldococcus infernus (strain DSM 11812 / JCM 15783 / ME)", "Methanocaldococcus jannaschii (strain ATCC 43067 / DSM 2661 / JAL-1 / JCM 10045 / NBRC 100440)", "Methanocaldococcus sp. (strain FS406-22)", "Methanocaldococcus vulcanius (strain ATCC 700851 / DSM 12094 / M7)")"Methanocaldococcus", "Methanotorris igneus (strain DSM 5666 / JCM 11834 / Kol 5)")"Methanocaldococcaceae", (("Methanococcus aeolicus (strain ATCC BAA-1280 / DSM 17508 / OCM 812 / Nankai-3)", (METMI, "Methanococcus maripaludis (strain C5 / ATCC BAA-1333)", "Methanococcus maripaludis (strain C6 / ATCC BAA-1332)", "Methanococcus maripaludis (strain C7 / ATCC BAA-1331)", "Methanococcus maripaludis (strain S2 / LL)")"Methanococcus maripaludis", "Methanococcus vannielii (strain ATCC 35089 / DSM 1224 / JCM 13029 / OCM 148 / SB)", "Methanococcus voltae (strain ATCC BAA-1334 / A3)")"Methanococcus", "Methanothermococcus okinawensis (strain DSM 14208 / JCM 11175 / IH1)")"Methanococcaceae")"Methanococcales", (("Methanocella arvoryzae (strain DSM 22066 / NBRC 105507 / MRE50)", "Methanocella conradii (strain DSM 24694 / JCM 17849 / CGMCC 1.5162 / HZ254)", "Methanocella paludicola (strain DSM 17711 / JCM 13418 / NBRC 101707 / SANAE)")"Methanocella", ("Methanocorpusculum labreanum (strain ATCC 43576 / DSM 4855 / Z)", (("Methanoculleus bourgensis (strain ATCC 43281 / DSM 3045 / OCM 15 / MS2)", "Methanoculleus marisnigri (strain ATCC 35101 / DSM 1498 / JR1)")"Methanoculleus", "Methanolacinia petrolearia (strain DSM 11571 / OCM 486 / SEBR 4847)")"Methanomicrobiaceae", (("Methanoregula boonei (strain DSM 21154 / JCM 14090 / 6A8)", "Methanoregula formicica (strain DSM 22288 / NBRC 105244 / SMSP)")"Methanoregula", "Methanosphaerula palustris (strain ATCC BAA-1556 / DSM 19958 / E1-9c)")"Methanoregulaceae", "Methanospirillum hungatei JF-1 (strain ATCC 27890 / DSM 864 / NBRC 100397 / JF-1)")"Methanomicrobiales", (("Methanosaeta concilii (strain ATCC 5969 / DSM 3671 / JCM 10134 / NBRC 103675 / OCM 69 / GP-6)", "Methanosaeta harundinacea (strain 6Ac)", "Methanosaeta thermophila (strain DSM 6194 / JCM 14653 / NBRC 101360 / PT)")"Methanosaeta", ("Methanococcoides burtonii (strain DSM 6242 / NBRC 107633 / OCM 468 / ACE-M)", "Methanohalobium evestigatum (strain ATCC BAA-1072 / DSM 3721 / NBRC 107634 / OCM 161 / Z-7303)", "Methanohalophilus mahii (strain ATCC 35705 / DSM 5219 / SLP)", "Methanomethylovorans hollandica (strain DSM 15978 / NBRC 107637 / DMS1)", "Methanosalsum zhilinae (strain DSM 4017 / NBRC 107636 / OCM 62 / WeN5)", ("Methanosarcina acetivorans (strain ATCC 35395 / DSM 2834 / JCM 12185 / C2A)", "Methanosarcina barkeri (strain Fusaro / DSM 804)", "Methanosarcina mazei (strain ATCC BAA-159 / DSM 3647 / Goe1 / Go1 / JCM 11833 / OCM 88)")"Methanosarcina")"Methanosarcinaceae")"Methanosarcinales")"Methanomicrobia", "Methanopyrus kandleri (strain AV19 / DSM 6324 / JCM 9639 / NBRC 100938)", (("Pyrococcus abyssi (strain GE5 / Orsay)", "Pyrococcus furiosus (strain ATCC 43587 / DSM 3638 / JCM 8422 / Vc1)", "Pyrococcus horikoshii (strain ATCC 700860 / DSM 12428 / JCM 9974 / NBRC 100139 / OT-3)", "Pyrococcus sp. (strain NA2)", "Pyrococcus yayanosii (strain CH1 / JCM 16557)")"Pyrococcus", ("Thermococcus barophilus (strain DSM 11836 / MP)", "Thermococcus gammatolerans (strain DSM 15229 / JCM 11827 / EJ3)", "Thermococcus kodakarensis (strain ATCC BAA-918 / JCM 12380 / KOD1)", "Thermococcus litoralis (strain ATCC 51850 / DSM 5473 / JCM 8560 / NS-C)", "Thermococcus onnurineus (strain NA1)", "Thermococcus sibiricus (strain MM 739 / DSM 12597)", "Thermococcus sp. (strain CGMCC 1.5172 / 4557)")"Thermococcus")"Thermococcaceae", (("Methanomethylophilus alvus (strain Mx1201)", "Methanomassiliicoccus intestinalis (strain Issoire-Mx1)")"Methanomassiliicoccaceae", ("Picrophilus torridus (strain ATCC 700027 / DSM 9790 / JCM 10055 / NBRC 100828)", ("Thermoplasma acidophilum (strain ATCC 25905 / DSM 1728 / JCM 9062 / NBRC 15155 / AMRC-C165)", "Thermoplasma volcanium (strain ATCC 51530 / DSM 4299 / JCM 9571 / NBRC 15438 / GSS1)")"Thermoplasma", "Thermoplasmatales archaeon (strain BRNA1)")"Thermoplasmatales")"Thermoplasmata", ("Aciduliprofundum boonei (strain DSM 19572 / T469)", "Aciduliprofundum sp. (strain MAR08-339)")"Aciduliprofundum")"Euryarchaeota", "Nanoarchaeum equitans (strain Kin4-M)", ("Cenarchaeum symbiosum (strain A)", "Nitrosopumilus maritimus (strain SCM1)", "Nitrososphaera gargensis (strain Ga9.2)")"Thaumarchaeota")"Archaea", ((("Acidobacterium capsulatum (strain ATCC 51196 / DSM 11244 / JCM 7670 / NBRC 15755 / NCIMB 13165 / 161)", "Koribacter versatilis (strain Ellin345)", ("Granulicella mallensis (strain ATCC BAA-1857 / DSM 23137 / MP5ACTX8)", "Granulicella tundricola (strain ATCC BAA-1859 / DSM 23138 / MP5ACTX9)")"Granulicella", ("Terriglobus roseus (strain DSM 18391 / NRRL B-41598 / KBS 63)", "Terriglobus saanensis (strain ATCC BAA-1853 / DSM 23119 / SP1PR4)")"Terriglobus")"Acidobacteriaceae", "Chloracidobacterium thermophilum (strain B)", "Solibacter usitatus (strain Ellin6076)")"Acidobacteria", ("Acidimicrobium ferrooxidans (strain DSM 10331 / JCM 15462 / NBRC 103882 / ICP)", "Acidothermus cellulolyticus (strain ATCC 43068 / 11B)", "Thermobispora bispora (strain ATCC 19993 / DSM 43833 / CBS 139.67 / JCM 10125 / NBRC 14880 / R51)", ("Arcanobacterium haemolyticum (strain ATCC 9345 / DSM 20595 / NBRC 15585 / NCTC 8452 / 11018)", "Mobiluncus curtisii (strain ATCC 43063 / DSM 2711 / V125)")"Actinomycetaceae", (("Bifidobacterium adolescentis (strain ATCC 15703 / DSM 20083 / NCTC 11814 / E194a)", ("Bifidobacterium animalis subsp. animalis (strain ATCC 25527 / DSM 20104 / JCM 1190 / R101-8)", ("Bifidobacterium animalis subsp. lactis (strain AD011)", "Bifidobacterium animalis subsp. lactis (strain BB-12)", "Bifidobacterium animalis subsp. lactis (strain Bl-04 / DGCC2908 / RB 4825 / SD5219)", "Bifidobacterium animalis subsp. lactis (strain DSM 10140 / JCM 10602 / LMG 18314)", "Bifidobacterium animalis subsp. lactis (strain V9)")"Bifidobacterium animalis subsp. lactis")"Bifidobacterium animalis", "Bifidobacterium asteroides (strain PRL2011)", ("Bifidobacterium bifidum (strain PRL2010)", "Bifidobacterium bifidum (strain S17)")"Bifidobacterium bifidum", "Bifidobacterium breve (strain ACS-071-V-Sch8b)", "Bifidobacterium dentium (strain ATCC 27534 / DSM 20436 / JCM 1195 / Bd1)", ("Bifidobacterium longum (strain DJO10A)", "Bifidobacterium longum (strain NCC 2705)", ("Bifidobacterium longum subsp. infantis (strain 157F)", "Bifidobacterium longum subsp. infantis (strain ATCC 15697 / DSM 20088 / JCM 1222 / NCTC 11817 / S12)")"Bifidobacterium longum subsp. infantis", ("Bifidobacterium longum subsp. longum (strain ATCC 15707 / DSM 20219 / JCM 1217 / NCTC 11818 / E194b)", "Bifidobacterium longum subsp. longum (strain BBMN68)", "Bifidobacterium longum subsp. longum (strain JDM301)")"Bifidobacterium longum subsp. longum")"Bifidobacterium longum")"Bifidobacterium", ("Gardnerella vaginalis (strain 409-05)", "Gardnerella vaginalis (strain ATCC 14019 / 317)", "Gardnerella vaginalis (strain HMP9231)")"Gardnerella vaginalis")"Bifidobacteriaceae", "Catenulispora acidiphila (strain DSM 44928 / NRRL B-24433 / NBRC 102108 / JCM 14897)", ((("Atopobium parvulum (strain ATCC 33793 / DSM 20469 / JCM 10300 / VPI 0546)", "Olsenella uli (strain ATCC 49627 / DSM 7084 / CIP 109912 / JCM 12494 / NCIMB 702895 / VPI D76D-27C)")"Atopobiaceae", "Coriobacterium glomerans (strain ATCC 49209 / DSM 20642 / JCM 10262 / PW2)")"Coriobacteriales", ("Cryptobacterium curtum (strain ATCC 700683 / DSM 15641 / 12-3)", "Eggerthella lenta (strain ATCC 25559 / DSM 2243 / JCM 9979 / NCTC 11813 / VPI 0255)", "Slackia heliotrinireducens (strain ATCC 29202 / DSM 20476 / NCTC 11029 / RHS 1)")"Eggerthellaceae")"Coriobacteriia", (("Corynebacterium aurimucosum (strain ATCC 700975 / DSM 44827 / CN-1)", ("Corynebacterium diphtheriae (strain 241)", "Corynebacterium diphtheriae (strain 31A)", "Corynebacterium diphtheriae (strain ATCC 27012 / C7 (beta))", "Corynebacterium diphtheriae (strain ATCC 700971 / NCTC 13129 / Biotype gravis)", "Corynebacterium diphtheriae (strain CDCE 8392)", "Corynebacterium diphtheriae (strain HC01)", "Corynebacterium diphtheriae (strain HC02)", "Corynebacterium diphtheriae (strain HC03)", "Corynebacterium diphtheriae (strain HC04)", "Corynebacterium diphtheriae (strain PW8)", "Corynebacterium diphtheriae (strain VA01)")"Corynebacterium diphtheriae", "Corynebacterium efficiens (strain DSM 44549 / YS-314 / AJ 12310 / JCM 11189 / NBRC 100395)", ((CORGL, "Corynebacterium glutamicum (strain ATCC 13032 / K051)")"Corynebacterium glutamicum (strain ATCC 13032 / DSM 20300 / JCM 1318 / LMG 3730 / NCIMB 10025)", "Corynebacterium glutamicum (strain R)")"Corynebacterium glutamicum", "Corynebacterium jeikeium (strain K411)", "Corynebacterium kroppenstedtii (strain DSM 44385 / JCM 11950 / CIP 105744 / CCUG 35717)", ("Corynebacterium pseudotuberculosis (strain 1002)", "Corynebacterium pseudotuberculosis (strain C231)", "Corynebacterium pseudotuberculosis (strain FRC41)", "Corynebacterium pseudotuberculosis (strain I19)")"Corynebacterium pseudotuberculosis", "Corynebacterium resistens (strain DSM 45100 / JCM 12819 / GTC 2026)", "Corynebacterium ulcerans (strain BR-AD22)", "Corynebacterium urealyticum (strain ATCC 43042 / DSM 7109)", "Corynebacterium variabile (strain DSM 44702 / JCM 12073 / NCIMB 30131)")"Corynebacterium", ("Gordonia bronchialis (strain ATCC 25592 / DSM 43247 / JCM 3198 / NCTC 10667)", "Gordonia polyisoprenivorans (strain DSM 44266 / VH2)")"Gordonia", ("Hoyosella subflava (strain DSM 45089 / JCM 17490 / NBRC 109087 / DQS3-9A1)", ("Mycobacterium abscessus (strain ATCC 19977 / DSM 44196 / CIP 104536 / JCM 13569 / NCTC 13031 / TMC 1543)", "Mycobacterium asiaticum", (("Mycobacterium avium (strain 104)", "Mycobacterium paratuberculosis (strain ATCC BAA-968 / K-10)")"Mycobacterium avium", "Mycobacterium intracellulare (strain ATCC 13950 / DSM 43223 / JCM 6384 / NCTC 13025 / 3600)")"Mycobacterium avium complex (MAC)", "Mycobacterium chubuense (strain NBB4)", ("Mycobacterium gilvum (strain DSM 45189 / LMG 24558 / Spyr1)", "Mycobacterium gilvum (strain PYR-GCK)")"Mycobacterium gilvum", ("Mycobacterium leprae (strain Br4923)", "Mycobacterium leprae (strain TN)")"Mycobacterium leprae", "Mycobacterium marinum (strain ATCC BAA-535 / M)", "Mycobacterium rhodesiae (strain NBB3)", "Mycobacterium sinense (strain JDM601)", "Mycobacterium smegmatis (strain ATCC 700084 / mc(2)155)", "Mycobacterium sp. (strain JLS)", "Mycobacterium sp. (strain KMS)", "Mycobacterium sp. (strain MCS)", ("Mycobacterium africanum (strain GM041182)", ("Mycobacterium bovis (strain ATCC BAA-935 / AF2122/97)", ("Mycobacterium bovis (strain BCG / Pasteur 1173P2)", "Mycobacterium bovis (strain BCG / Tokyo 172 / ATCC 35737 / TMC 1019)")"Mycobacterium bovis BCG")"Mycobacterium bovis", "Mycobacterium canettii (strain CIPT 140010059)", ("Mycobacterium tuberculosis (strain ATCC 25177 / H37Ra)", "Mycobacterium tuberculosis (strain ATCC 25618 / H37Rv)", "Mycobacterium tuberculosis (strain CCDC5079)", "Mycobacterium tuberculosis (strain CCDC5180)", "Mycobacterium tuberculosis (strain F11)", "Mycobacterium tuberculosis (strain KZN 1435 / MDR)")"Mycobacterium tuberculosis")"Mycobacterium tuberculosis complex", "Mycobacterium ulcerans (strain Agy99)", "Mycobacterium vanbaalenii (strain DSM 7251 / PYR-1)")"Mycobacterium")"Mycobacteriaceae", (("Nocardia cyriacigeorgica (strain GUH-2)", "Nocardia farcinica (strain IFM 10152)")"Nocardia", ("Rhodococcus erythropolis (strain PR4 / NBRC 100887)", "Rhodococcus equi (strain 103S)", "Rhodococcus jostii (strain RHA1)", "Rhodococcus opacus (strain B4)")"Rhodococcus")"Nocardiaceae", "Segniliparus rotundus (strain ATCC BAA-972 / CDC 1076 / CIP 108378 / DSM 44985 / JCM 13578)", "Tsukamurella paurometabola (strain ATCC 8368 / DSM 20162 / JCM 10117 / NBRC 16120 / NCTC 13040)")"Corynebacteriales", ("Frankia alni (strain ACN14a)", "Frankia casuarinae (strain DSM 45818 / CECT 9043 / CcI3)", "Frankia inefficax (strain DSM 45817 / CECT 9037 / EuI1c)", "Frankia sp. (strain EAN1pec)", "Frankia symbiont subsp. Datisca glomerata")"Frankia", ("Blastococcus saxobsidens (strain DD2)", "Geodermatophilus obscurus (strain ATCC 25078 / DSM 43160 / JCM 3152 / G-20)", "Modestobacter marinus (strain BC501)")"Geodermatophilaceae", "Stackebrandtia nassauensis (strain DSM 44728 / NRRL B-16338 / NBRC 102104 / LLR-40K-21)", "Kineococcus radiotolerans (strain ATCC BAA-149 / DSM 14245 / SRS30216)", ("Beutenbergia cavernae (strain ATCC BAA-8 / DSM 12333 / NBRC 16432)", ("Cellulomonas fimi (strain ATCC 484 / DSM 20113 / JCM 1341 / NBRC 15513 / NCIMB 8980 / NCTC 7547)", "Cellulomonas flavigena (strain ATCC 482 / DSM 20109 / NCIB 8073 / NRS 134)", "Cellulomonas gilvus (strain ATCC 13127 / NRRL B-14078)")"Cellulomonas", "Brachybacterium faecium (strain ATCC 43885 / DSM 4810 / NCIB 9860)", "Kytococcus sedentarius (strain ATCC 14392 / DSM 20547 / CCM 314 / 541)", "Jonesia denitrificans (strain ATCC 14870 / DSM 20603 / CIP 55134)", (("Clavibacter michiganensis subsp. michiganensis (strain NCPPB 382)", "Clavibacter michiganensis subsp. sepedonicus (strain ATCC 33113 / DSM 20744 / JCM 9667 / LMG 2889 / C-1)")"Clavibacter michiganensis", "Leifsonia xyli subsp. xyli (strain CTCB07)", "Microbacterium testaceum (strain StLB037)")"Microbacteriaceae", ("Arthrobacter sp. (strain FB24)", "Glutamicibacter arilaitensis (strain DSM 16368 / CIP 108037 / IAM 15318 / JCM 13566 / Re117)", "Kocuria rhizophila (strain ATCC 9341 / DSM 348 / NBRC 103217 / DC2201)", "Micrococcus luteus (strain ATCC 4698 / DSM 20030 / JCM 1464 / NBRC 3333 / NCIMB 9278 / NCTC 2665 / VKM Ac-2230)", "Paenarthrobacter aurescens (strain TC1)", ("Pseudarthrobacter chlorophenolicus (strain ATCC 700700 / DSM 12829 / CIP 107037 / JCM 12360 / KCTC 9906 / NCIMB 13794 / A6)", "Pseudarthrobacter phenanthrenivorans (strain DSM 18606 / JCM 16027 / LMG 23796 / Sphe3)")"Pseudarthrobacter", "Renibacterium salmoninarum (strain ATCC 33209 / DSM 20767 / JCM 11484 / NBRC 15589 / NCIMB 2235)", ("Rothia dentocariosa (strain ATCC 17931 / CDC X599 / XDIA)", "Rothia mucilaginosa (strain DY-18)")"Rothia")"Micrococcaceae", "Xylanimonas cellulosilytica (strain DSM 15894 / CECT 5975 / LMG 20990 / XIL07)", "Sanguibacter keddieii (strain ATCC 51767 / DSM 10542 / NCFB 3025 / ST-74)", ("Tropheryma whipplei (strain TW08/27)", "Tropheryma whipplei (strain Twist)")"Tropheryma whipplei")"Micrococcales", (("Actinoplanes missouriensis (strain ATCC 14538 / DSM 43046 / CBS 188.64 / JCM 3121 / NCIMB 12654 / NBRC 102363 / 431)", "Actinoplanes sp. (strain ATCC 31044 / CBS 674.73 / SE50/110)")"Actinoplanes", ("Micromonospora aurantiaca (strain ATCC 27029 / DSM 43813 / BCRC 12538 / CBS 129.76 / JCM 10878 / NBRC 16125 / NRRL B-16091 / INA 9442)", "Micromonospora sp. (strain L5)")"Micromonospora", ("Salinispora arenicola (strain CNS-205)", "Salinispora tropica (strain ATCC BAA-916 / DSM 44818 / CNB-440)")"Salinispora", "Verrucosispora maris (strain AB-18-032)")"Micromonosporaceae", "Nakamurella multipartita (strain ATCC 700099 / DSM 44233 / CIP 104796 / JCM 9543 / NBRC 105858 / Y-104)", (("Kribbella flavida (strain DSM 17836 / JCM 10339 / NBRC 14399)", "Nocardioides sp. (strain ATCC BAA-499 / JS614)")"Nocardioidaceae", ("Acidipropionibacterium acidipropionici (strain ATCC 4875 / DSM 20272 / JCM 6432 / NBRC 12425 / NCIMB 8070)", ("Propionibacterium acnes (strain KPA171202 / DSM 16379)", "Propionibacterium acnes (strain SK137)")"Cutibacterium acnes", "Microlunatus phosphovorus (strain ATCC 700054 / DSM 10555 / JCM 9379 / NBRC 101784 / NCIMB 13414 / VKM Ac-1990 / NM-1)", "Propionibacterium freudenreichii subsp. shermanii (strain ATCC 9614 / DSM 4902 / CIP 103027 / NCIMB 8099 / CIRM-BIA1)", "Pseudopropionibacterium propionicum (strain F0230a)")"Propionibacteriaceae")"Propionibacteriales", ("Actinosynnema mirum (strain ATCC 29888 / DSM 43827 / NBRC 14064 / IMRU 3971)", ("Amycolatopsis mediterranei (strain S699)", "Amycolatopsis mediterranei (strain U-32)")"Amycolatopsis mediterranei", "Pseudonocardia dioxanivorans (strain ATCC 55486 / DSM 44775 / JCM 13855 / CB1190)", "Saccharomonospora viridis (strain ATCC 15386 / DSM 43017 / JCM 3036 / NBRC 12207 / P101)", "Saccharopolyspora erythraea (strain ATCC 11635 / DSM 40517 / JCM 4748 / NBRC 13426 / NCIMB 8594 / NRRL 2338)", "Saccharothrix espanaensis (strain ATCC 51144 / DSM 44229 / JCM 9112 / NBRC 15066 / NRRL 15764)")"Pseudonocardiaceae", "Rubrobacter xylanophilus (strain DSM 9941 / NBRC 16129)", ("Kitasatospora setae (strain ATCC 33774 / DSM 43861 / JCM 3304 / KCC A-0304 / NBRC 14216 / KM-6054)", ("Streptomyces avermitilis (strain ATCC 31267 / DSM 46492 / JCM 5070 / NBRC 14893 / NCIMB 12804 / NRRL 8165 / MA-4680)", "Streptomyces bingchenggensis (strain BCW-1)", "Streptomyces cattleya (strain ATCC 35852 / DSM 46488 / JCM 4925 / NBRC 14057 / NRRL 8057)", "Streptomyces coelicolor (strain ATCC BAA-471 / A3(2) / M145)", "Streptomyces griseus subsp. griseus (strain JCM 4626 / NBRC 13350)", "Streptomyces hygroscopicus subsp. jinggangensis (strain 5008)", "Streptomyces pratensis (strain ATCC 33331 / IAF-45CD)", "Streptomyces scabiei (strain 87.22)", "Streptomyces venezuelae (strain ATCC 10712 / CBS 650.69 / DSM 40230 / JCM 4526 / NBRC 13096 / PD 04745)")"Streptomyces")"Streptomycetaceae", ((("Nocardiopsis alba (strain ATCC BAA-2165 / BE74)", "Nocardiopsis dassonvillei (strain ATCC 23218 / DSM 43111 / CIP 107115 / JCM 7437 / KCTC 9190 / NBRC 14626 / NCTC 10488 / NRRL B-5397 / IMRU 509)")"Nocardiopsis", "Thermobifida fusca (strain YX)")"Nocardiopsaceae", "Streptosporangium roseum (strain ATCC 12428 / DSM 43021 / JCM 3005 / NI 9100)", "Thermomonospora curvata (strain ATCC 19995 / DSM 43183 / JCM 3096 / NBRC 15933 / NCIMB 10081 / Henssen B9)")"Streptosporangiales", "Conexibacter woesei (strain DSM 14684 / JCM 11494 / NBRC 100937 / ID131577)")"Actinobacteria", ((("Aquifex aeolicus (strain VF5)", "Hydrogenobacter thermophilus (strain DSM 6534 / IAM 12695 / TK-6)", "Hydrogenobaculum sp. (strain Y04AAS1)", "Thermocrinis albus (strain DSM 14484 / JCM 11386 / HI 11/12)")"Aquificaceae", ("Persephonella marina (strain DSM 14350 / EX-H1)", ("Sulfurihydrogenibium azorense (strain Az-Fu1 / DSM 15241 / OCM 825)", "Sulfurihydrogenibium sp. (strain YO3AOP1)")"Sulfurihydrogenibium")"Hydrogenothermaceae")"Aquificales", ("Desulfurobacterium thermolithotrophum (strain DSM 11699 / BSA)", "Thermovibrio ammonificans (strain DSM 15698 / JCM 12110 / HB-1)")"Desulfurobacteriaceae")"Aquificae", (("Rhodothermus marinus (strain ATCC 43812 / DSM 4252 / R-10)", ("Salinibacter ruber (strain DSM 13855 / M31)", "Salinibacter ruber (strain M8)")"Salinibacter ruber")"Rhodothermaceae", ((("Bacteroides fragilis (strain 638R)", "Bacteroides fragilis (strain ATCC 25285 / DSM 2151 / JCM 11019 / NCTC 9343)", "Bacteroides fragilis (strain YCH46)")"Bacteroides fragilis", "Bacteroides helcogenes (strain ATCC 35417 / DSM 20613 / JCM 6297 / P 36-108)", "Bacteroides salanitronis (strain DSM 18170 / JCM 13567 / BL78)", "Bacteroides thetaiotaomicron (strain ATCC 29148 / DSM 2079 / NCTC 10582 / E50 / VPI-5482)", "Bacteroides vulgatus (strain ATCC 8482 / DSM 1447 / JCM 5826 / NBRC 14291 / NCTC 11154)")"Bacteroides", "Odoribacter splanchnicus (strain ATCC 29572 / DSM 20712 / CIP 104287 / JCM 15291 / NCTC 10825 / 1651/6)", "Paludibacter propionicigenes (strain DSM 17365 / JCM 13257 / WB4)", ("Porphyromonas asaccharolytica (strain ATCC 25260 / DSM 20707 / BCRC 10618 / JCM 6326 / LMG 13178 / VPI 4198)", ("Porphyromonas gingivalis (strain ATCC 33277 / DSM 20709 / CIP 103683 / JCM 12257 / NCTC 11834 / 2561)", "Porphyromonas gingivalis (strain ATCC BAA-308 / W83)")"Porphyromonas gingivalis")"Porphyromonas", ("Prevotella denticola (strain F0289)", "Prevotella intermedia (strain 17)", "Prevotella melaninogenica (strain ATCC 25845 / DSM 7089 / JCM 6325 / VPI 2381 / B282)", "Prevotella ruminicola (strain ATCC 19189 / JCM 8958 / 23)")"Prevotella", "Alistipes finegoldii (strain DSM 17242 / JCM 16770 / AHN 2437 / CCUG 46020 / CIP 107999)", ("Parabacteroides distasonis (strain ATCC 8503 / DSM 20701 / CIP 104284 / JCM 5825 / NCTC 11152)", "Tannerella forsythia (strain ATCC 43037 / JCM 10827 / FDC 338)")"Tannerellaceae", "Azobacteroides pseudotrichonymphae genomovar. CFP2")"Bacteroidales", ("Chitinophaga pinensis (strain ATCC 43595 / DSM 2588 / NCIB 11800 / UQM 2034)", "Niastella koreensis (strain DSM 17620 / KACC 11465 / GR20-10)")"Chitinophagaceae", ("Amoebophilus asiaticus (strain 5a2)", "Bernardetia litoralis (strain ATCC 23117 / DSM 6794 / NBRC 15988 / NCIMB 1366 / Sio-4)", ("Belliella baltica (strain DSM 15883 / CIP 108006 / LMG 21964 / BA134)", "Cyclobacterium marinum (strain ATCC 25205 / DSM 745)", "Echinicola vietnamensis (strain DSM 17526 / LMG 23754 / KMM 6221)")"Cyclobacteriaceae", ("Cytophaga hutchinsonii (strain ATCC 33406 / NCIMB 9469)", "Dyadobacter fermentans (strain ATCC 700827 / DSM 18053 / NS114)", "Emticicia oligotrophica (strain DSM 17448 / GPTSA100-15)", "Leadbetterella byssophila (strain DSM 17132 / KACC 11308 / 4M15)", "Runella slithyformis (strain ATCC 29530 / DSM 19594 / LMG 11500 / NCIMB 11436 / LSU 4)", "Spirosoma linguale (strain ATCC 33905 / DSM 74 / LMG 10896)")"Cytophagaceae", "Marivirga tractuosa (strain ATCC 23168 / DSM 4126 / NBRC 15989 / NCIMB 1408 / VKM B-1430 / H-43)")"Cytophagales", (("Blattabacterium sp. subsp. Blattella germanica (strain Bge)", "Blattabacterium sp. subsp. Periplaneta americana (strain BPLAN)")"Blattabacterium", "Fluviicola taffensis (strain DSM 16823 / NCIMB 13979 / RW262)", "Owenweeksia hongkongensis (strain DSM 17368 / CIP 108786 / JCM 12287 / NRRL B-23963 / UST20020801)", ("Aequorivita sublithincola (strain DSM 14238 / LMG 21431 / ACAM 643 / 9-3)", ("Capnocytophaga canimorsus (strain 5)", "Capnocytophaga ochracea (strain ATCC 27872 / DSM 7271 / JCM 12966 / NCTC 12371 / VPI 2845)")"Capnocytophaga", ("Cellulophaga algicola (strain DSM 14237 / IC166 / ACAM 630)", "Cellulophaga lytica (strain ATCC 23178 / DSM 7489 / JCM 8516 / NBRC 14961 / NCIMB 1423 / VKM B-1433 / Cy l20)")"Cellulophaga", "Croceibacter atlanticus (strain ATCC BAA-628 / HTCC2559 / KCTC 12090)", "Dokdonia sp. (strain 4H-3-7-5)", ("Flavobacterium branchiophilum (strain FL-15)", "Flavobacterium columnare (strain ATCC 49512 / CIP 103533 / TG 44/87)", "Flavobacterium indicum (strain DSM 17447 / CIP 109464 / GPTSA100-9)", "Flavobacterium johnsoniae (strain ATCC 17061 / DSM 2064 / UW101)", "Flavobacterium psychrophilum (strain JIP02/86 / ATCC 49511)")"Flavobacterium", "Gramella forsetii (strain KT0803)", "Lacinutrix sp. (strain 5H-3-7-4)", "Leeuwenhoekiella blandensis (strain CECT 7118 / CCUG 51940 / MED217)", "Maribacter sp. (strain HTCC2170 / KCCM 42371)", "Muricauda ruestringensis (strain DSM 13258 / CIP 107369 / LMG 19739 / B1)", "Nonlabens dokdonensis (strain DSM 17205 / KCTC 12402 / DSW-6)", "Ornithobacterium rhinotracheale (strain ATCC 51463 / DSM 15997 / CCUG 23171 / CIP 104009 / LMG 9086)", "Psychroflexus torquis (strain ATCC 700755 / ACAM 623)", "Riemerella anatipestifer (strain RA-GD)", "Robiginitalea biformata (strain ATCC BAA-864 / HTCC2501 / KCTC 12146)", "Weeksella virosa (strain ATCC 43766 / DSM 16922 / JCM 21250 / NBRC 16016 / NCTC 11634 / CL345/78)", "Zobellia galactanivorans (strain DSM 12802 / CCUG 47099 / CIP 106680 / NCIMB 13871 / Dsij)", "Zunongwangia profunda (strain DSM 18752 / CCTCC AB 206139 / SM-A87)", "Flavobacteriaceae bacterium (strain 3519-10)")"Flavobacteriaceae", ("Sulcia muelleri (strain CARI)", "Sulcia muelleri (strain DMIN)", "Sulcia muelleri (strain GWSS)", "Sulcia muelleri (strain SMDSEM)")"Candidatus Sulcia muelleri")"Flavobacteriales", ("Haliscomenobacter hydrossis (strain ATCC 27775 / DSM 1100 / LMG 10767 / O)", "Saprospira grandis (strain Lewin)")"Saprospirales", ("Pedobacter heparinus (strain ATCC 13125 / DSM 2366 / CIP 104194 / JCM 7457 / NBRC 12017 / NCIMB 9290 / NRRL B-14731 / HIM 762-3)", "Pseudopedobacter saltans (strain ATCC 51119 / DSM 12145 / JCM 21818 / LMG 10337 / NBRC 100064 / NCIMB 13643)", "Solitalea canadensis (strain ATCC 29591 / DSM 3403 / NBRC 15130 / NCIMB 12057 / USAM 9D)", "Sphingobacterium sp. (strain 21)")"Sphingobacteriaceae")"Bacteroidetes", "Caldisericum exile (strain DSM 21853 / NBRC 104410 / AZM16c01)", "Cloacimonas acidaminovorans (strain Evry)", (("Chlamydia abortus (strain DSM 27085 / S26/3)", "Chlamydophila caviae (strain GPIC)", "Chlamydia felis (strain Fe/C-56)", "Chlamydia muridarum (strain MoPn / Nigg)", "Chlamydophila pecorum (strain ATCC VR-628 / E58)", (CHLPN, "Chlamydophila pneumoniae (strain LPCoLN)")"Chlamydia pneumoniae", ("Chlamydia trachomatis (strain D/UW-3/Cx)", "Chlamydia trachomatis (strain L2c)", "Chlamydia trachomatis serovar A (strain A2497)", "Chlamydia trachomatis serovar A (strain ATCC VR-571B / DSM 19440 / HAR-13)", "Chlamydia trachomatis serovar B (strain Jali20/OT)", "Chlamydia trachomatis serovar B (strain TZ1A828/OT)", "Chlamydia trachomatis serovar D (strain D-EC)", "Chlamydia trachomatis serovar D (strain D-LC)", "Chlamydia trachomatis serovar E (strain E/11023)", "Chlamydia trachomatis serovar E (strain E/150)", "Chlamydia trachomatis serovar E (strain Sweden2)", "Chlamydia trachomatis serovar G (strain G/11074)", "Chlamydia trachomatis serovar G (strain G/11222)", "Chlamydia trachomatis serovar G (strain G/9301)", "Chlamydia trachomatis serovar G (strain G/9768)", "Chlamydia trachomatis serovar L2 (strain 434/Bu / ATCC VR-902B)", "Chlamydia trachomatis serovar L2b (strain UCH-1/proctitis)")"Chlamydia trachomatis", ("Chlamydophila psittaci (strain ATCC VR-125 / 6BC)", "Chlamydophila psittaci (strain RD1)")"Chlamydophila psittaci")"Chlamydia", (("Protochlamydia amoebophila (strain UWE25)", "Parachlamydia acanthamoebae (strain UV7)")"Parachlamydiaceae", "Simkania negevensis (strain ATCC VR-1471 / Z)", "Waddlia chondrophila (strain ATCC VR-1470 / WSU 86-1044)")"Parachlamydiales")"Chlamydiia", (("Chlorobaculum parvum (strain NCIB 8327)", "Chlorobium tepidum (strain ATCC 49652 / DSM 12025 / NBRC 103806 / TLS)")"Chlorobaculum", ("Chlorobium chlorochromatii (strain CaD3)", "Chlorobium limicola (strain DSM 245 / NBRC 103803 / 6330)", ("Chlorobium phaeobacteroides (strain BS1)", "Chlorobium phaeobacteroides (strain DSM 266)")"Chlorobium phaeobacteroides", "Chlorobium phaeovibrioides (strain DSM 265 / 1930)")"Chlorobium", "Chloroherpeton thalassium (strain ATCC 35110 / GB-78)", ("Chlorobium luteolum (strain DSM 273 / 2530)", "Pelodictyon phaeoclathratiforme (strain DSM 5477 / BU-1)")"Pelodictyon", "Prosthecochloris aestuarii (strain DSM 271 / SK 413)")"Chlorobiaceae", ("Anaerolinea thermophila (strain DSM 14523 / JCM 11388 / NBRC 100420 / UNI-1)", "Caldilinea aerophila (strain DSM 14535 / JCM 11387 / NBRC 104270 / STL-6-O1)", ((("Chloroflexus aggregans (strain MD-66 / DSM 9485)", "Chloroflexus aurantiacus (strain ATCC 29366 / DSM 635 / J-10-fl)", "Chloroflexus aurantiacus (strain ATCC 29364 / DSM 637 / Y-400-fl)")"Chloroflexus", ("Roseiflexus castenholzii (strain DSM 13941 / HLO8)", "Roseiflexus sp. (strain RS-1)")"Roseiflexus")"Chloroflexales", "Herpetosiphon aurantiacus (strain ATCC 23779 / DSM 785)")"Chloroflexia", (("Dehalococcoides mccartyi (strain ATCC BAA-2100 / JCM 16839 / KCTC 5957 / BAV1)", "Dehalococcoides mccartyi (strain ATCC BAA-2266 / KCTC 15142 / 195)", "Dehalococcoides mccartyi (strain CBDB1)", "Dehalococcoides mccartyi (strain GT)", "Dehalococcoides mccartyi (strain VS)")"Dehalococcoides mccartyi", "Dehalogenimonas lykanthroporepellens (strain ATCC BAA-1523 / JCM 15061 / BL-DC-9)")"Dehalococcoidia", ("Sphaerobacter thermophilus (strain DSM 20745 / S 6022)", "Thermomicrobium roseum (strain ATCC 27502 / DSM 5159 / P-2)")"Thermomicrobia")"Chloroflexi", "Desulfurispirillum indicum (strain ATCC BAA-1389 / S5)", ("Gloeobacter violaceus (strain PCC 7421)", (("Anabaena cylindrica (strain ATCC 27899 / PCC 7122)", "Anabaena variabilis (strain ATCC 29413 / PCC 7937)")"Anabaena", ("Nostoc punctiforme (strain ATCC 29133 / PCC 73102)", "Nostoc sp. (strain ATCC 29411 / PCC 7524)", "Nostoc sp. (strain PCC 7120 / SAG 25.82 / UTEX 2576)")"Nostoc", "Nostoc azollae (strain 0708)")"Nostocaceae", ((("Atelocyanobacterium thalassa (isolate ALOHA)", "Halothece sp. (strain PCC 7418)")"Aphanothecaceae", ("Cyanobacterium aponinum (strain PCC 10605)", "Cyanobacterium stanieri (strain ATCC 29140 / PCC 7202)")"Cyanobacterium", "Microcystis aeruginosa (strain NIES-843)")"Chroococcales", (("Cyanothece sp. (strain ATCC 51142)", "Cyanothece sp. (strain PCC 7424)", "Cyanothece sp. (strain PCC 7425 / ATCC 29141)", "Cyanothece sp. (strain PCC 7822)", "Cyanothece sp. (strain PCC 8801)", "Cyanothece sp. (strain PCC 8802)")"Cyanothece", ("Arthrospira platensis (strain NIES-39 / IAM M-135)", "Trichodesmium erythraeum (strain IMS101)")"Microcoleaceae", "Lyngbya sp. (strain PCC 8106)")"Oscillatoriales")"Oscillatoriophycideae", "Stanieria cyanosphaera (strain ATCC 29371 / PCC 7437)", ("Acaryochloris marina (strain MBIC 11017)", "Synechocystis sp. (strain PCC 6803 / Kazusa)", ("Prochlorococcus marinus (strain AS9601)", "Prochlorococcus marinus (strain MIT 9211)", "Prochlorococcus marinus (strain MIT 9215)", "Prochlorococcus marinus (strain MIT 9301)", "Prochlorococcus marinus (strain MIT 9303)", "Prochlorococcus marinus (strain MIT 9312)", "Prochlorococcus marinus (strain MIT 9313)", "Prochlorococcus marinus (strain MIT 9515)", "Prochlorococcus marinus (strain NATL1A)", "Prochlorococcus marinus (strain NATL2A)", "Prochlorococcus marinus (strain SARG / CCMP1375 / SS120)", "Prochlorococcus marinus subsp. pastoris (strain CCMP1986 / NIES-2087 / MED4)")"Prochlorococcus marinus", ("Cyanobium gracile (strain ATCC 27147 / PCC 6307)", ("Synechococcus sp. (strain ATCC 27144 / PCC 6301 / SAUG 1402/1)", "Synechococcus sp. (strain ATCC 27264 / PCC 7002 / PR-6)", "Synechococcus sp. (strain ATCC 29403 / PCC 7335)", "Synechococcus sp. (strain CC9311)", "Synechococcus sp. (strain CC9605)", "Synechococcus sp. (strain CC9902)", "Synechococcus sp. (strain JA-2-3B\'a(2-13))", "Synechococcus sp. (strain JA-3-3Ab)", "Synechococcus sp. (strain RCC307)", "Synechococcus sp. (strain WH7803)", "Synechococcus sp. (strain WH8102)")"Synechococcus", "Thermosynechococcus elongatus (strain BP-1)")"Synechococcaceae")"Synechococcales")"Cyanobacteria", ("Calditerrivibrio nitroreducens (strain DSM 19672 / NBRC 101217 / Yu37-1)", "Deferribacter desulfuricans (strain DSM 14783 / JCM 11476 / NBRC 101012 / SSM1)", "Denitrovibrio acetiphilus (strain DSM 12809 / N2460)", "Flexistipes sinusarabici (strain DSM 4947 / MAS 10)")"Deferribacteraceae", ((("Deinococcus deserti (strain VCD115 / DSM 17065 / LMG 22923)", "Deinococcus geothermalis (strain DSM 11300)", "Deinococcus gobiensis (strain DSM 21396 / JCM 16679 / CGMCC 1.7299 / I-0)", "Deinococcus maricopensis (strain DSM 21211 / LMG 22137 / NRRL B-23946 / LB-34)", "Deinococcus peraridilitoris (strain DSM 19664 / LMG 22246 / CIP 109416 / KR-200)", "Deinococcus proteolyticus (strain ATCC 35074 / DSM 20540 / JCM 6276 / NBRC 101906 / NCIMB 13154 / VKM Ac-1939 / CCM 2703 / MRP)", "Deinococcus radiodurans (strain ATCC 13939 / DSM 20539 / JCM 16871 / LMG 4051 / NBRC 15346 / NCIMB 9279 / R1 / VKM B-1422)")"Deinococcus", "Truepera radiovictrix (strain DSM 17093 / CIP 108686 / LMG 22925 / RQ-24)")"Deinococcales", ("Marinithermus hydrothermalis (strain DSM 14884 / JCM 11576 / T1)", ("Meiothermus ruber (strain ATCC 35948 / DSM 1279 / VKM B-1258 / 21)", "Meiothermus silvanus (strain ATCC 700542 / DSM 9946 / VI-R2)")"Meiothermus", "Oceanithermus profundus (strain DSM 14977 / NBRC 100410 / VKM B-2274 / 506)", ("Thermus thermophilus (strain HB27 / ATCC BAA-163 / DSM 7039)", "Thermus thermophilus (strain HB8 / ATCC 27634 / DSM 579)", "Thermus thermophilus (strain SG0.5JP17-16)")"Thermus thermophilus")"Thermaceae")"Deinococci", ("Dictyoglomus thermophilum (strain ATCC 35947 / DSM 3960 / H-6-12)", "Dictyoglomus turgidum (strain Z-1310 / DSM 6724)")"Dictyoglomus", ("Elusimicrobium minutum (strain Pei191)", "Uncultured termite group 1 bacterium phylotype Rs-D17")"Elusimicrobia", "Fibrobacter succinogenes (strain ATCC 19169 / S85)", ((((("Alicyclobacillus acidocaldarius (strain Tc-4-1)", "Alicyclobacillus acidocaldarius subsp. acidocaldarius (strain ATCC 27009 / DSM 446 / JCM 5260 / NBRC 15652 / NCIMB 11725 / NRRL B-14509 / 104-1A)")"Alicyclobacillus acidocaldarius", "Kyrpidia tusciae (strain DSM 2912 / NBRC 15312 / T2)")"Alicyclobacillaceae", ("Amphibacillus xylanus (strain ATCC 51415 / DSM 6626 / JCM 7361 / LMG 17667 / NBRC 15112 / Ep01)", "Anoxybacillus flavithermus (strain DSM 21510 / WK1)", ("Bacillus amyloliquefaciens (strain ATCC 23350 / DSM 7 / BCRC 11601 / NBRC 15535 / NRRL B-14393)", (BACAN, "Bacillus anthracis (strain A0248)", "Bacillus anthracis (strain CDC 684 / NRRL 3495)")"Bacillus anthracis", "Bacillus atrophaeus (strain 1942)", "Bacillus cellulosilyticus (strain ATCC 21833 / DSM 2522 / FERM P-1141 / JCM 9156 / N-4)", ("Bacillus cereus (strain 03BB102)", "Bacillus cereus (strain AH187)", "Bacillus cereus (strain AH820)", "Bacillus cereus (strain ATCC 10987 / NRS 248)", "Bacillus cereus (strain ATCC 14579 / DSM 31 / JCM 2152 / NBRC 15305 / NCIMB 9373 / NRRL B-3711)", "Bacillus cereus (strain B4264)", "Bacillus cereus (strain G9842)", "Bacillus cereus (strain Q1)", "Bacillus cereus (strain ZK / E33L)", "Bacillus cereus var. anthracis (strain CI)")"Bacillus cereus", "Bacillus clausii (strain KSM-K16)", "Bacillus coagulans (strain 2-6)", "Bacillus cytotoxicus (strain DSM 22905 / CIP 110041 / 391-98 / NVH 391-98)", "Bacillus halodurans (strain ATCC BAA-125 / DSM 18197 / FERM 7344 / JCM 9153 / C-125)", "Bacillus licheniformis (strain ATCC 14580 / DSM 13 / JCM 2505 / NBRC 12200 / NCIMB 9375 / NRRL NRS-1264 / Gibson 46)", ("Bacillus megaterium (strain ATCC 12872 / QMB1551)", "Bacillus megaterium (strain DSM 319)")"Bacillus megaterium", "Bacillus pseudofirmus (strain OF4)", "Bacillus pumilus (strain SAFR-032)", ("Bacillus subtilis (strain BSn5)", ("Bacillus subtilis subsp. spizizenii (strain ATCC 23059 / NRRL B-14472 / W23)", "Bacillus subtilis subsp. spizizenii (strain TU-B-10)")"Bacillus subtilis subsp. spizizenii", "Bacillus subtilis (strain 168)")"Bacillus subtilis", ("Bacillus thuringiensis (strain Al Hakam)", "Bacillus thuringiensis subsp. finitimus (strain YBT-020)", "Bacillus thuringiensis subsp. konkukian (strain 97-27)", "Bacillus thuringiensis (strain BMB171)")"Bacillus thuringiensis", "Bacillus velezensis (strain DSM 23117 / BGSC 10A6 / FZB42)", "Bacillus weihenstephanensis (strain KBAB4)")"Bacillus", ("Geobacillus kaustophilus (strain HTA426)", "Geobacillus sp. (strain WCH70)", "Geobacillus sp. (strain Y4.1MC1)", "Geobacillus sp. (strain Y412MC61)", "Geobacillus thermodenitrificans (strain NG80-2)")"Geobacillus", "Lysinibacillus sphaericus (strain C3-41)", "Oceanobacillus iheyensis (strain DSM 14371 / CIP 107618 / JCM 11309 / KCTC 3954 / HTE831)", "Geobacillus thermoglucosidasius (strain C56-YS93)")"Bacillaceae", ("Exiguobacterium antarcticum (strain B7)", "Exiguobacterium sibiricum (strain DSM 17290 / JCM 13490 / 255-15)", "Exiguobacterium sp. (strain ATCC BAA-1283 / AT1b)")"Exiguobacterium", ("Listeria innocua serovar 6a (strain ATCC BAA-680 / CLIP 11262)", "Listeria ivanovii (strain ATCC BAA-678 / PAM 55)", ("Listeria monocytogenes serotype 1/2a (strain 08-5923)", "Listeria monocytogenes serotype 1/2a (strain 10403S)", "Listeria monocytogenes serotype 4a (strain HCC23)", "Listeria monocytogenes serotype 4a (strain L99)", "Listeria monocytogenes serotype 4a (strain M7)", "Listeria monocytogenes serotype 4b (strain CLIP80459)", "Listeria monocytogenes serotype 4b (strain F2365)", "Listeria monocytogenes serovar 1/2a (strain ATCC BAA-679 / EGD-e)")"Listeria monocytogenes", "Listeria seeligeri serovar 1/2b (strain ATCC 35967 / DSM 20751 / CIP 100100 / SLCC 3954)", "Listeria welshimeri serovar 6b (strain ATCC 35897 / DSM 20650 / SLCC5334)")"Listeria", ("Brevibacillus brevis (strain 47 / JCM 6285 / NBRC 100599)", ("Geobacillus sp. (strain Y412MC10)", "Paenibacillus mucilaginosus (strain KNP414)", ("Paenibacillus polymyxa (strain E681)", "Paenibacillus polymyxa (strain SC2)")"Paenibacillus polymyxa", "Paenibacillus sp. (strain JDR-2)", "Paenibacillus terrae (strain HPL-003)")"Paenibacillus", "Thermobacillus composti (strain DSM 18247 / JCM 13945 / KWC4)")"Paenibacillaceae", "Solibacillus silvestris (strain StLB046)", "Bacillus selenitireducens (strain ATCC 700615 / DSM 15326 / MLS10)", ("Macrococcus caseolyticus (strain JCSC5402)", (("Staphylococcus aureus (strain 04-02981)", "Staphylococcus aureus (strain bovine RF122 / ET3-1)", ("Staphylococcus aureus (strain COL)", "Staphylococcus aureus (strain ECT-R 2)", "Staphylococcus aureus (strain ED98)", "Staphylococcus aureus (strain JH1)", "Staphylococcus aureus (strain JH9)", "Staphylococcus aureus (strain JKD6008)", "Staphylococcus aureus (strain JKD6159)", "Staphylococcus aureus (strain MRSA ST398 / isolate S0385)", "Staphylococcus aureus (strain MRSA252)", "Staphylococcus aureus (strain MSSA476)", "Staphylococcus aureus (strain MW2)", "Staphylococcus aureus (strain Mu3 / ATCC 700698)", "Staphylococcus aureus (strain Mu50 / ATCC 700699)", "Staphylococcus aureus (strain N315)", "Staphylococcus aureus (strain NCTC 8325)", "Staphylococcus aureus (strain Newman)", "Staphylococcus aureus (strain TCH60)", "Staphylococcus aureus (strain TW20 / 0582)", (STAA3, "Staphylococcus aureus (strain USA300 / TCH1516)")"Staphylococcus aureus (strain USA300)", "Staphylococcus aureus subsp. aureus (strain ED133)")"Staphylococcus aureus subsp. aureus")"Staphylococcus aureus", "Staphylococcus carnosus (strain TM300)", ("Staphylococcus epidermidis (strain ATCC 12228)", "Staphylococcus epidermidis (strain ATCC 35984 / RP62A)")"Staphylococcus epidermidis", "Staphylococcus haemolyticus (strain JCSC1435)", "Staphylococcus lugdunensis (strain HKU09-01)", ("Staphylococcus pseudintermedius (strain ED99)", "Staphylococcus pseudintermedius (strain HKU10-03)")"Staphylococcus pseudintermedius", "Staphylococcus saprophyticus subsp. saprophyticus (strain ATCC 15305 / DSM 20229)")"Staphylococcus")"Staphylococcaceae")"Bacillales", ("Aerococcus urinae (strain ACS-120-V-Col10a)", "Carnobacterium sp. (strain 17-4)", ((("Enterococcus faecalis (strain 62)", "Enterococcus faecalis (strain ATCC 47077 / OG1RF)", "Enterococcus faecalis (strain ATCC 700802 / V583)")"Enterococcus faecalis", "Enterococcus faecium (strain Aus0004)")"Enterococcus", ("Melissococcus plutonius (strain ATCC 35311 / CIP 104052 / LMG 20360 / NCIMB 702443)", "Melissococcus plutonius (strain DAT561)")"Melissococcus plutonius", "Tetragenococcus halophilus (strain DSM 20338 / JCM 20259 / NCIMB 9735 / NBRC 12172)")"Enterococcaceae", ((("Lactobacillus acidophilus (strain 30SC)", "Lactobacillus acidophilus (strain ATCC 700396 / NCK56 / N2 / NCFM)")"Lactobacillus acidophilus", ("Lactobacillus amylovorus (strain GRL 1112)", "Lactobacillus amylovorus (strain GRL 1118)")"Lactobacillus amylovorus", "Lactobacillus brevis (strain ATCC 367 / JCM 1170)", "Lactobacillus buchneri (strain NRRL B-30929)", ("Lactobacillus casei (strain BD-II)", "Lactobacillus casei (strain BL23)", "Lactobacillus casei (strain LC2W)", "Lactobacillus casei (strain Zhang)")"Lactobacillus casei", "Lactobacillus crispatus (strain ST1)", ("Lactobacillus delbrueckii subsp. bulgaricus (strain 2038)", "Lactobacillus delbrueckii subsp. bulgaricus (strain ATCC 11842 / DSM 20081 / JCM 1002 / NBRC 13953 / NCIMB 11778)", "Lactobacillus delbrueckii subsp. bulgaricus (strain ATCC BAA-365)", "Lactobacillus delbrueckii subsp. bulgaricus (strain ND02)")"Lactobacillus delbrueckii subsp. bulgaricus", ("Lactobacillus fermentum (strain CECT 5716)", "Lactobacillus fermentum (strain NBRC 3956 / LMG 18251)")"Lactobacillus fermentum", "Lactobacillus gasseri (strain ATCC 33323 / DSM 20243 / JCM 1131 / NCIMB 11718 / AM63)", "Lactobacillus helveticus (strain DPC 4571)", ("Lactobacillus johnsonii (strain CNCM I-12250 / La1 / NCC 533)", "Lactobacillus johnsonii (strain FI9785)")"Lactobacillus johnsonii", "Lactobacillus kefiranofaciens (strain ZW3)", "Lactobacillus paracasei (strain ATCC 334 / BCRC 17002 / CIP 107868 / KCTC 3260 / NRRL B-441)", ("Lactobacillus plantarum (strain ATCC BAA-793 / NCIMB 8826 / WCFS1)", "Lactobacillus plantarum (strain JDM1)", "Lactobacillus plantarum (strain ST-III)")"Lactobacillus plantarum", ("Lactobacillus reuteri (strain ATCC 55730 / SD2112)", "Lactobacillus reuteri (strain DSM 20016)", "Lactobacillus reuteri (strain JCM 1112)")"Lactobacillus reuteri", ("Lactobacillus rhamnosus (strain ATCC 53103 / GG)", "Lactobacillus rhamnosus (strain Lc 705)")"Lactobacillus rhamnosus", "Lactobacillus ruminis (strain ATCC 27782 / RF3)", "Lactobacillus sakei subsp. sakei (strain 23K)", ("Lactobacillus salivarius (strain CECT 5713)", "Lactobacillus salivarius (strain UCC118)")"Lactobacillus salivarius", "Lactobacillus sanfranciscensis (strain TMW 1.1304)")"Lactobacillus", ("Pediococcus claussenii (strain ATCC BAA-344 / DSM 14800 / JCM 18046 / KCTC 3811 / P06)", "Pediococcus pentosaceus (strain ATCC 25745 / CCUG 21536 / LMG 10740 / 183-1w)")"Pediococcus")"Lactobacillaceae", (("Leuconostoc carnosum (strain JB16)", "Leuconostoc citreum (strain KM20)", ("Leuconostoc gelidum (strain JB7)", "Leuconostoc gelidum subsp. gasicomitatum (strain DSM 15947 / CECT 5767 / JCM 12535 / LMG 18811 / TB1-10)")"Leuconostoc gelidum", "Leuconostoc mesenteroides subsp. mesenteroides (strain ATCC 8293 / NCDO 523)", "Leuconostoc sp. (strain C2)")"Leuconostoc", "Oenococcus oeni (strain ATCC BAA-331 / PSU-1)", "Weissella koreensis (strain KACC 15510)")"Leuconostocaceae", ((("Lactococcus garvieae (strain ATCC 49156 / DSM 6783 / NCIMB 13208 / YT-3)", "Lactococcus garvieae (strain Lg2)")"Lactococcus garvieae", (("Lactococcus lactis subsp. cremoris (strain MG1363)", "Lactococcus lactis subsp. cremoris (strain NZ9000)", "Lactococcus lactis subsp. cremoris (strain SK11)")"Lactococcus lactis subsp. cremoris", ("Lactococcus lactis subsp. lactis (strain CV56)", "Lactococcus lactis subsp. lactis (strain IL1403)", "Lactococcus lactis subsp. lactis (strain KF147)")"Lactococcus lactis subsp. lactis")"Lactococcus lactis")"Lactococcus", (("Streptococcus agalactiae serotype III (strain NEM316)", "Streptococcus agalactiae serotype Ia (strain ATCC 27591 / A909 / CDC SS700)", "Streptococcus agalactiae serotype V (strain ATCC BAA-611 / 2603 V/R)", "Streptococcus agalactiae serotype Ia (strain GD201008-001)")"Streptococcus agalactiae", ("Streptococcus dysgalactiae subsp. equisimilis (strain ATCC 12394 / D166B)", "Streptococcus dysgalactiae subsp. equisimilis (strain GGS_124)")"Streptococcus dysgalactiae subsp. equisimilis", ("Streptococcus equi subsp. equi (strain 4047)", ("Streptococcus equi subsp. zooepidemicus (strain ATCC 35246 / C74-63)", "Streptococcus equi subsp. zooepidemicus (strain H70)", "Streptococcus equi subsp. zooepidemicus (strain MGCS10565)")"Streptococcus equi subsp. zooepidemicus")"Streptococcus equi", ("Streptococcus gallolyticus (strain ATCC 43143 / F-1867)", "Streptococcus gallolyticus (strain ATCC BAA-2069)", "Streptococcus gallolyticus (strain UCN34)")"Streptococcus gallolyticus", "Streptococcus gordonii (strain Challis / ATCC 35105 / BCRC 15272 / CH1 / DL1 / V288)", "Streptococcus infantarius (strain CJ18)", "Streptococcus intermedius (strain JTH08)", "Streptococcus macedonicus (strain ACA-DC 198)", "Streptococcus mitis (strain B6)", ("Streptococcus mutans serotype c (strain ATCC 700610 / UA159)", "Streptococcus mutans serotype c (strain NN2025)")"Streptococcus mutans", "Streptococcus oralis (strain Uo5)", "Streptococcus parauberis (strain KCTC 11537)", "Streptococcus pasteurianus (strain ATCC 43144 / JCM 5346 / CDC 1723-81)", ("Streptococcus pneumoniae (strain 670-6B)", "Streptococcus pneumoniae (strain 70585)", "Streptococcus pneumoniae (strain ATCC 700669 / Spain 23F-1)", "Streptococcus pneumoniae (strain ATCC BAA-255 / R6)", "Streptococcus pneumoniae (strain CGSP14)", "Streptococcus pneumoniae (strain Hungary19A-6)", "Streptococcus pneumoniae (strain JJA)", "Streptococcus pneumoniae (strain P1031)", "Streptococcus pneumoniae (strain ST556)", "Streptococcus pneumoniae (strain Taiwan19F-14)", "Streptococcus pneumoniae serotype 1 (strain INV104)", "Streptococcus pneumoniae serotype 14 (strain INV200)", "Streptococcus pneumoniae serotype 19F (strain G54)", "Streptococcus pneumoniae serotype 2 (strain D39 / NCTC 7466)", "Streptococcus pneumoniae serotype 3 (strain OXC141)", "Streptococcus pneumoniae serotype 4 (strain ATCC BAA-334 / TIGR4)", "Streptococcus pneumoniae serotype A19 (strain TCH8431)")"Streptococcus pneumoniae", "Streptococcus pseudopneumoniae (strain IS7493)", ("Streptococcus pyogenes serotype M1", ("Streptococcus pyogenes serotype M12 (strain MGAS2096)", "Streptococcus pyogenes serotype M12 (strain MGAS9429)")"Streptococcus pyogenes serotype M12", "Streptococcus pyogenes serotype M18 (strain MGAS8232)", "Streptococcus pyogenes serotype M2 (strain MGAS10270)", "Streptococcus pyogenes serotype M28 (strain MGAS6180)", ("Streptococcus pyogenes serotype M3 (strain ATCC BAA-595 / MGAS315)", "Streptococcus pyogenes serotype M3 (strain SSI-1)")"Streptococcus pyogenes serotype M3", "Streptococcus pyogenes serotype M4 (strain MGAS10750)", "Streptococcus pyogenes serotype M49 (strain NZ131)", "Streptococcus pyogenes serotype M5 (strain Manfredo)", "Streptococcus pyogenes serotype M6 (strain ATCC BAA-946 / MGAS10394)")"Streptococcus pyogenes", ("Streptococcus salivarius (strain 57.I)", "Streptococcus salivarius (strain CCHSS3)", "Streptococcus salivarius (strain JIM8777)")"Streptococcus salivarius", "Streptococcus sanguinis (strain SK36)", ("Streptococcus suis (strain 05ZYH33)", "Streptococcus suis (strain 98HAH33)", "Streptococcus suis (strain BM407)", "Streptococcus suis (strain GZ1)", "Streptococcus suis (strain JS14)", "Streptococcus suis (strain P1/7)", "Streptococcus suis (strain SC84)")"Streptococcus suis", ("Streptococcus thermophilus (strain ATCC BAA-250 / LMG 18311)", "Streptococcus thermophilus (strain ATCC BAA-491 / LMD-9)", "Streptococcus thermophilus (strain CNRZ 1066)", "Streptococcus thermophilus (strain ND03)")"Streptococcus thermophilus", "Streptococcus uberis (strain ATCC BAA-854 / 0140J)")"Streptococcus")"Streptococcaceae")"Lactobacillales")"Bacilli", (((("Alkaliphilus metalliredigens (strain QYMF)", "Alkaliphilus oremlandii (strain OhILAs)")"Alkaliphilus", "Arthromitus sp. (strain SFB-mouse-Japan)", (("Clostridium acetobutylicum (strain ATCC 824 / DSM 792 / JCM 1419 / LMG 5710 / VKM B-1787)", "Clostridium acetobutylicum (strain EA 2018)")"Clostridium acetobutylicum", "Clostridium beijerinckii (strain ATCC 51743 / NCIMB 8052)", ("Clostridium botulinum (strain H04402 065 / Type A5)", ("Clostridium botulinum (strain ATCC 19397 / Type A)", "Clostridium botulinum (strain Hall / ATCC 3502 / NCTC 13319 / Type A)", "Clostridium botulinum (strain Kyoto / Type A2)", "Clostridium botulinum (strain Loch Maree / Type A3)")"Clostridium botulinum A", ("Clostridium botulinum (strain 657 / Type Ba4)", "Clostridium botulinum (strain Eklund 17B / Type B)", "Clostridium botulinum (strain Okra / Type B1)")"Clostridium botulinum B", "Clostridium botulinum (strain Alaska E43 / Type E3)", ("Clostridium botulinum (strain 230613 / Type F)", "Clostridium botulinum (strain Langeland / NCTC 10281 / Type F)")"Clostridium botulinum F")"Clostridium botulinum", "Clostridium cellulovorans (strain ATCC 35296 / DSM 3052 / OCM 3 / 743B)", "Clostridium kluyveri (strain ATCC 8527 / DSM 555 / NCIMB 10680)", "Clostridium ljungdahlii (strain ATCC 55383 / DSM 13528 / PETC)", "Clostridium novyi (strain NT)", ("Clostridium perfringens (strain 13 / Type A)", "Clostridium perfringens (strain ATCC 13124 / DSM 756 / JCM 1290 / NCIMB 6125 / NCTC 8237 / Type A)", "Clostridium perfringens (strain SM101 / Type A)")"Clostridium perfringens", "Clostridium sp. (strain SY8519)", "Clostridium tetani (strain Massachusetts / E88)")"Clostridium")"Clostridiaceae", (("Sulfobacillus acidophilus (strain ATCC 700253 / DSM 10332 / NAL)", "Sulfobacillus acidophilus (strain TPY)")"Sulfobacillus acidophilus", "Thermaerobacter marianensis (strain ATCC 700841 / DSM 12885 / JCM 10246 / 7p75a)")"Clostridiales Family XVII. Incertae Sedis", ("Acetobacterium woodii (strain ATCC 29683 / DSM 1030 / JCM 2381 / KCTC 1655 / WB1)", ("Eubacterium limosum (strain KIST612)", "Eubacterium eligens (strain ATCC 27750 / VPI C15-48)")"Eubacterium")"Eubacteriaceae", "Heliobacterium modesticaldum (strain ATCC 51547 / Ice1)", ("Butyrivibrio proteoclasticus (strain ATCC 51982 / DSM 14932 / B316)", "Cellulosilyticum lentocellum (strain ATCC 49066 / DSM 5427 / NCIMB 11756 / RHM5)", ("Clostridium saccharolyticum (strain ATCC 35040 / DSM 2544 / NRCC 2533 / WM1)", "Lachnoclostridium phytofermentans (strain ATCC 700394 / DSM 18823 / ISDg)")"Lachnoclostridium", "Roseburia hominis (strain DSM 16839 / NCIMB 14029 / A2-183)", "Agathobacter rectalis (strain ATCC 33656 / DSM 3377 / JCM 17463 / KCTC 5835 / VPI 0990)")"Lachnospiraceae", "Oscillibacter valericigenes (strain DSM 18026 / NBRC 101213 / Sjm18-20)", ("Desulforudis audaxviator (strain MP104C)", ("Desulfitobacterium dichloroeliminans (strain LMG P-21439 / DCA1)", ("Desulfitobacterium hafniense (strain DCB-2 / DSM 10664)", "Desulfitobacterium hafniense (strain Y51)")"Desulfitobacterium hafniense")"Desulfitobacterium", ("Desulfosporosinus acidiphilus (strain DSM 22704 / JCM 16185 / SJ4)", "Desulfosporosinus meridiei (strain ATCC BAA-275 / DSM 13257 / NCIMB 13706 / S10)", "Desulfosporosinus orientis (strain ATCC 19365 / DSM 765 / NCIMB 8382 / VKM B-1628)")"Desulfosporosinus", ("Desulfotomaculum acetoxidans (strain ATCC 49208 / DSM 771 / VKM B-1644)", "Desulfotomaculum kuznetsovii (strain DSM 6115 / VKM B-1805 / 17)", "Desulfotomaculum nigrificans (strain DSM 14880 / VKM B-2319 / CO-1-SRB)", "Desulfotomaculum reducens (strain MI-1)", "Desulfotomaculum ruminis (strain ATCC 23193 / DSM 2154 / NCIB 8452 / DL)")"Desulfotomaculum", "Pelotomaculum thermopropionicum (strain DSM 13744 / JCM 10971 / SI)", "Syntrophobotulus glycolicus (strain DSM 8271 / FlGlyR)", "Thermincola potens (strain JR)")"Peptococcaceae", ("Acetoanaerobium sticklandii (strain ATCC 12662 / DSM 519 / JCM 1433 / NCIMB 10654)", ("Peptoclostridium difficile (strain 630)", "Peptoclostridium difficile (strain R20291)")"Clostridioides difficile", "Filifactor alocis (strain ATCC 35896 / D40 B5)")"Peptostreptococcaceae", ("Ethanoligenens harbinense (strain DSM 18485 / JCM 12961 / CGMCC 1.5033 / YUAN-3)", "Mageeibacillus indolicus (strain UPII9-5)", (("Clostridium thermocellum (strain ATCC 27405 / DSM 1237 / NBRC 103400 / NCIMB 10682 / NRRL B-4536 / VPI 7372)", "Clostridium thermocellum (strain DSM 1313 / LMG 6656 / LQ8)")"Clostridium thermocellum", "Clostridium cellulolyticum (strain ATCC 35319 / DSM 5812 / JCM 6584 / H10)", "Clostridium clariflavum (strain DSM 19732 / NBRC 101661 / EBR45)")"Ruminiclostridium", ("Ruminococcus albus (strain ATCC 27210 / DSM 20455 / JCM 14654 / NCDO 2250 / 7)", "Ruminococcus champanellensis (strain DSM 18848 / JCM 17042 / KCTC 15320 / 18P13)")"Ruminococcus")"Ruminococcaceae", "Symbiobacterium thermophilum (strain T / IAM 14863)", ("Syntrophomonas wolfei subsp. wolfei (strain DSM 2245B / Goettingen)", "Syntrophothermus lipocalidus (strain DSM 12680 / TGB-C1)")"Syntrophomonadaceae", "Clostridium acidurici (strain ATCC 7906 / CIP 104303 / DSM 604 / NCIMB 10678 / BCRC 14475 / NCCB 46094 / 9a)")"Clostridiales", ((("Halanaerobium hydrogeniformans", "Halanaerobium praevalens (strain ATCC 33744 / DSM 2228 / GSL)")"Halanaerobium", "Halothermothrix orenii (strain H 168 / OCM 544 / DSM 9562)")"Halanaerobiaceae", ("Acetohalobium arabaticum (strain ATCC 49924 / DSM 5501 / Z-7288)", "Halobacteroides halobius (strain ATCC 35273 / DSM 5150 / MD-1)")"Halobacteroidaceae")"Halanaerobiales", "Natranaerobius thermophilus (strain ATCC BAA-1301 / DSM 18059 / JW/NM-WN-LF)", (("Caldanaerobacter subterraneus subsp. tengcongensis (strain DSM 15242 / JCM 11007 / NBRC 100824 / MB4)", "Carboxydothermus hydrogenoformans (strain ATCC BAA-161 / DSM 6008 / Z-2901)", "Moorella thermoacetica (strain ATCC 39073 / JCM 9320)", "Tepidanaerobacter acetatoxydans (strain DSM 21804 / JCM 16047 / Re1)", ("Thermoanaerobacter italicus (strain DSM 9252 / Ab9)", "Thermoanaerobacter mathranii subsp. mathranii (strain DSM 11426 / CIP 108742 / A3)", "Thermoanaerobacter pseudethanolicus (strain ATCC 33223 / 39E)", "Thermoanaerobacter sp. (strain X513)", "Thermoanaerobacter sp. (strain X514)")"Thermoanaerobacter")"Thermoanaerobacteraceae", (("Caldicellulosiruptor bescii (strain ATCC BAA-1888 / DSM 6725 / Z-1320)", "Caldicellulosiruptor hydrothermalis (strain DSM 18901 / VKM B-2411 / 108)", "Caldicellulosiruptor kristjanssonii (strain ATCC 700853 / DSM 12137 / I77R1B)", "Caldicellulosiruptor kronotskyensis (strain DSM 18902 / VKM B-2412 / 2002)", "Caldicellulosiruptor obsidiansis (strain ATCC BAA-2073 / strain OB47)", "Caldicellulosiruptor owensensis (strain ATCC 700167 / DSM 13100 / OL)", "Caldicellulosiruptor saccharolyticus (strain ATCC 43494 / DSM 8903 / Tp8T 6331)")"Caldicellulosiruptor", ("Thermoanaerobacterium saccharolyticum (strain DSM 8691 / JW/SL-YS485)", "Thermoanaerobacterium thermosaccharolyticum (strain ATCC 7956 / DSM 571 / NCIB 9385 / NCA 3814)", "Thermoanaerobacterium xylanolyticum (strain ATCC 49914 / DSM 7097 / LX-11)")"Thermoanaerobacterium", "Thermosediminibacter oceani (strain ATCC BAA-1034 / DSM 16646 / JW/IW-1228P)")"Thermoanaerobacterales Family III. Incertae Sedis", "Mahella australiensis (strain DSM 15567 / CIP 107919 / 50-1 BON)", "Coprothermobacter proteolyticus (strain ATCC 35245 / DSM 5265 / BT)")"Thermoanaerobacterales")"Clostridia", "Erysipelothrix rhusiopathiae (strain Fujisawa)", (("Acidaminococcus fermentans (strain ATCC 25085 / DSM 20731 / VR4)", "Acidaminococcus intestini (strain RyC-MR95)")"Acidaminococcus", ("Selenomonas ruminantium subsp. lactilytica (strain NBRC 103574 / TAM6421)", "Selenomonas sputigena (strain ATCC 35185 / DSM 20758 / VPI D19B-28)")"Selenomonas", "Veillonella parvula (strain ATCC 10790 / DSM 2008 / JCM 12972 / Te3)")"Negativicutes", ("Anaerococcus prevotii (strain ATCC 9321 / DSM 20548 / JCM 6508 / PC1)", "Finegoldia magna (strain ATCC 29328)")"Peptoniphilaceae")"Firmicutes", (("Fusobacterium nucleatum subsp. nucleatum (strain ATCC 25586 / CIP 101130 / JCM 8532 / LMG 13131)", "Ilyobacter polytropus (strain DSM 2926 / CuHBu1)")"Fusobacteriaceae", ("Leptotrichia buccalis (strain ATCC 14201 / DSM 1135 / JCM 12969 / NCTC 10249 / C-1013-b)", "Sebaldella termitidis (strain ATCC 33386 / NCTC 11300)", "Streptobacillus moniliformis (strain ATCC 14647 / DSM 12112 / NCTC 10651 / 9901)")"Leptotrichiaceae")"Fusobacteriales", "Gemmatimonas aurantiaca (strain T-27 / DSM 14586 / JCM 11422 / NBRC 100505)", ("Ignavibacterium album (strain DSM 19864 / JCM 16511 / NBRC 101810 / Mat9-16)", "Melioribacter roseus (strain JCM 17771 / P3M-2)")"Ignavibacteriales", (("Leptospirillum ferrooxidans (strain C2-3)", "Leptospirillum ferriphilum (strain ML-04)")"Leptospirillum", "Thermodesulfovibrio yellowstonii (strain ATCC 51303 / DSM 11347 / YP87)")"Nitrospiraceae", ("Phycisphaera mikurensis (strain NBRC 102666 / KCTC 22515 / FYK2301M01)", (("Isosphaera pallida (strain ATCC 43644 / DSM 9630 / IS1B)", "Singulisphaera acidiphila (strain ATCC BAA-1392 / DSM 18658 / VKM B-2454 / MOB10)")"Isosphaeraceae", ("Pirellula staleyi (strain ATCC 27377 / DSM 6068 / ICPB 4128)", "Planctopirus limnophila (strain ATCC 43296 / DSM 3776 / IFAM 1008 / 290)", "Rhodopirellula baltica (strain DSM 10527 / NCIMB 13988 / SH1)", "Rubinisphaera brasiliensis (strain ATCC 49424 / DSM 5305 / JCM 21570 / NBRC 103401 / IFAM 1448)")"Planctomycetaceae")"Planctomycetales")"Planctomycetes", (("Acidithiobacillus caldus (strain SM-1)", ("Acidithiobacillus ferrooxidans (strain ATCC 23270 / DSM 14882 / CIP 104768 / NCIMB 8455)", "Acidithiobacillus ferrooxidans (strain ATCC 53993)")"Acidithiobacillus ferrooxidans")"Acidithiobacillus", (("Asticcacaulis excentricus (strain ATCC 15261 / DSM 4724 / VKM B-1370 / CB 48)", "Brevundimonas subvibrioides (strain ATCC 15264 / DSM 4735 / LMG 14903 / NBRC 16000 / CB 81)", ("Caulobacter segnis (strain ATCC 21756 / DSM 7131 / JCM 7823 / NBRC 15250 / LMG 17158 / TK0059)", "Caulobacter sp. (strain K31)", (CAUCR, "Caulobacter crescentus (strain NA1000 / CB15N)")"Caulobacter crescentus (strain ATCC 19089 / CB15)")"Caulobacter", "Phenylobacterium zucineum (strain HLK1)")"Caulobacteraceae", "Magnetococcus marinus (strain ATCC BAA-1437 / JCM 17883 / MC-1)", "Parvularcula bermudensis (strain ATCC BAA-594 / HTCC2503 / KCTC 12087)", ("Pelagibacter sp. (strain IMCC9063)", "Pelagibacter ubique (strain HTCC1062)")"Candidatus Pelagibacter", (("Bartonella bacilliformis (strain ATCC 35685 / KC583)", "Bartonella clarridgeiae (strain CIP 104772 / 73)", "Bartonella grahamii (strain as4aup)", "Bartonella henselae (strain ATCC 49882 / DSM 28221 / Houston 1)", "Bartonella quintana (strain Toulouse)", "Bartonella tribocorum (strain CIP 105476 / IBS 506)", "Bartonella vinsonii subsp. berkhoffii (strain Winnie)")"Bartonella", ("Beijerinckia indica subsp. indica (strain ATCC 9039 / DSM 1715 / NCIB 8712)", "Methylocella silvestris (strain DSM 15510 / CIP 108128 / LMG 27833 / NCIMB 13906 / BL2)")"Beijerinckiaceae", (("Bradyrhizobium diazoefficiens (strain JCM 10833 / IAM 13628 / NBRC 14792 / USDA 110)", "Bradyrhizobium sp. (strain BTAi1 / ATCC BAA-1182)", "Bradyrhizobium sp. (strain ORS 278)")"Bradyrhizobium", ("Nitrobacter hamburgensis (strain DSM 10229 / NCIMB 13809 / X14)", "Nitrobacter winogradskyi (strain ATCC 25391 / DSM 10237 / CIP 104748 / NCIMB 11846 / Nb-255)")"Nitrobacter", ("Oligotropha carboxidovorans (strain ATCC 49405 / DSM 1227 / KCTC 32145 / OM5)", "Oligotropha carboxidovorans (strain OM4)")"Oligotropha carboxidovorans", ("Rhodopseudomonas palustris (strain ATCC BAA-98 / CGA009)", "Rhodopseudomonas palustris (strain BisA53)", "Rhodopseudomonas palustris (strain BisB18)", "Rhodopseudomonas palustris (strain BisB5)", "Rhodopseudomonas palustris (strain DX-1)", "Rhodopseudomonas palustris (strain HaA2)", "Rhodopseudomonas palustris (strain TIE-1)")"Rhodopseudomonas palustris")"Bradyrhizobiaceae", ((("Brucella abortus (strain 2308)", "Brucella abortus (strain S19)", "Brucella abortus biovar 1 (strain 9-941)")"Brucella abortus", "Brucella canis (strain ATCC 23365 / NCTC 10854)", ("Brucella melitensis (strain M5-90)", "Brucella melitensis biotype 1 (strain 16M / ATCC 23456 / NCTC 10094)", "Brucella melitensis biotype 2 (strain ATCC 23457)")"Brucella melitensis", "Brucella microti (strain CCM 4915)", "Brucella ovis (strain ATCC 25840 / 63/290 / NCTC 10512)", ("Brucella suis biovar 1 (strain 1330)", "Brucella suis (strain ATCC 23445 / NCTC 10510)")"Brucella suis")"Brucella", "Ochrobactrum anthropi (strain ATCC 49188 / DSM 6882 / JCM 21032 / NBRC 15819 / NCTC 12168)")"Brucellaceae", (("Hyphomicrobium denitrificans (strain ATCC 51888 / DSM 1869 / NCIB 11706 / TK 0415)", "Hyphomicrobium sp. (strain MC1)")"Hyphomicrobium", "Pelagibacterium halotolerans (strain DSM 22347 / JCM 15775 / CGMCC 1.7692 / B2)", "Rhodomicrobium vannielii (strain ATCC 17100 / ATH 3.1.1 / DSM 162 / LMG 4299)")"Hyphomicrobiaceae", (("Methylobacterium extorquens (strain ATCC 14718 / DSM 1338 / JCM 2805 / NCIMB 9133 / AM1)", "Methylobacterium extorquens (strain CM4 / NCIMB 13688)", "Methylobacterium extorquens (strain DSM 6343 / CIP 106787 / DM4)", "Methylobacterium extorquens (strain PA1)")"Methylobacterium extorquens", "Methylobacterium nodulans (strain LMG 21967 / CNCM I-2342 / ORS 2060)", "Methylobacterium populi (strain ATCC BAA-705 / NCIMB 13946 / BJ001)", "Methylobacterium radiotolerans (strain ATCC 27329 / DSM 1819 / JCM 2831)", "Methylobacterium sp. (strain 4-46)")"Methylobacterium", "Methylocystis sp. (strain SC2)", ("Chelativorans sp. (strain BNC1)", ("Mesorhizobium australicum (strain HAMBI 3006 / LMG 24608 / WSM2073)", "Mesorhizobium ciceri biovar biserrulae (strain HAMBI 2942 / LMG 23838 / WSM1271)", "Rhizobium loti (strain MAFF303099)")"Mesorhizobium")"Phyllobacteriaceae", (("Agrobacterium sp. (strain H13-3)", ("Agrobacterium fabrum (strain C58 / ATCC 33970)", "Agrobacterium radiobacter (strain K84 / ATCC BAA-868)")"Agrobacterium tumefaciens complex", "Agrobacterium vitis (strain S4 / ATCC BAA-846)")"Agrobacterium", "Liberibacter asiaticus (strain psy62)", (("Rhizobium etli (strain CFN 42 / ATCC 51251)", "Rhizobium etli (strain CIAT 652)")"Rhizobium etli", (("Rhizobium leguminosarum bv. trifolii (strain WSM1325)", "Rhizobium leguminosarum bv. trifolii (strain WSM2304)")"Rhizobium leguminosarum bv. trifolii", "Rhizobium leguminosarum bv. viciae (strain 3841)")"Rhizobium leguminosarum")"Rhizobium", (("Rhizobium fredii (strain HH103)", "Sinorhizobium fredii (strain NBRC 101917 / NGR234)")"Rhizobium fredii", ("Rhizobium meliloti (strain 1021)", "Sinorhizobium meliloti (strain AK83)", "Sinorhizobium meliloti (strain BL225C)", "Sinorhizobium meliloti (strain SM11)")"Rhizobium meliloti", "Sinorhizobium medicae (strain WSM419)")"Sinorhizobium")"Rhizobiaceae", "Parvibaculum lavamentivorans (strain DS-1 / DSM 13023 / NCIMB 13966)", ("Azorhizobium caulinodans (strain ATCC 43989 / DSM 5975 / JCM 20966 / NBRC 14845 / NCIMB 13405 / ORS 571)", "Starkeya novella (strain ATCC 8093 / DSM 506 / CCM 1077 / IAM 12100 / NBRC 12443 / NCIB 9113)", "Xanthobacter autotrophicus (strain ATCC BAA-1158 / Py2)")"Xanthobacteraceae", "Hodgkinia cicadicola (strain Dsem)")"Rhizobiales", (("Hirschia baltica (strain ATCC 49814 / DSM 5838 / IFAM 1418)", "Hyphomonas neptunium (strain ATCC 15444)", "Maricaulis maris (strain MCS10)")"Hyphomonadaceae", ("Dinoroseobacter shibae (strain DSM 16493 / NCIMB 14021 / DFL 12)", "Jannaschia sp. (strain CCS1)", ("Ketogulonicigenium vulgare (strain WSH-001)", "Ketogulonicigenium vulgare (strain Y25)")"Ketogulonicigenium vulgare", "Paracoccus denitrificans (strain Pd 1222)", "Phaeobacter inhibens (strain ATCC 700781 / DSM 17395 / CIP 105210 / JCM 21319 / NBRC 16654 / NCIMB 13546 / BS107)", "Pseudovibrio sp. (strain FO-BEG1)", ("Rhodobacter capsulatus (strain ATCC BAA-309 / NBRC 16581 / SB1003)", ("Rhodobacter sphaeroides (strain ATCC 17023 / 2.4.1 / NCIB 8253 / DSM 158)", "Rhodobacter sphaeroides (strain ATCC 17025 / ATH 2.4.3)", "Rhodobacter sphaeroides (strain ATCC 17029 / ATH 2.4.9)", "Rhodobacter sphaeroides (strain KD131 / KCTC 12085)")"Rhodobacter sphaeroides")"Rhodobacter", ("Roseobacter denitrificans (strain ATCC 33942 / OCh 114)", "Roseobacter litoralis (strain ATCC 49566 / DSM 6996 / JCM 21268 / NBRC 15278 / OCh 149)")"Roseobacter", ("Ruegeria pomeroyi (strain ATCC 700808 / DSM 15171 / DSS-3)", "Ruegeria sp. (strain TM1040)")"Ruegeria")"Rhodobacteraceae")"Rhodobacterales", (("Acetobacter pasteurianus (strain NBRC 3283 / LMG 1513 / CCTM 1153)", ("Acidiphilium cryptum (strain JF-5)", "Acidiphilium multivorum (strain DSM 11245 / JCM 8867 / NBRC 100883 / AIU301)")"Acidiphilium", "Gluconacetobacter diazotrophicus (strain ATCC 49037 / DSM 5601 / PAl5)", "Gluconobacter oxydans (strain 621H)", "Granulibacter bethesdensis (strain ATCC BAA-1260 / CGDNIH1)", "Komagataeibacter medellinensis (strain NBRC 3288 / BCRC 11682 / LMG 1693 / Kondo 51)")"Acetobacteraceae", ("Azospirillum lipoferum (strain 4B)", "Magnetospirillum magneticum (strain AMB-1 / ATCC 700264)", ("Rhodospirillum centenum (strain ATCC 51521 / SW)", "Rhodospirillum rubrum (strain ATCC 11170 / ATH 1.1.1 / DSM 467 / LMG 4362 / NCIB 8255 / S1)")"Rhodospirillum", "Tistrella mobilis (strain KA081020-065)")"Rhodospirillaceae")"Rhodospirillales", (((("Anaplasma marginale (strain Florida)", "Anaplasma marginale (strain St. Maries)")"Anaplasma marginale", "Anaplasma phagocytophilum (strain HZ)")"Anaplasma", ("Ehrlichia canis (strain Jake)", "Ehrlichia chaffeensis (strain ATCC CRL-10679 / Arkansas)", ("Ehrlichia ruminantium (strain Gardel)", "Ehrlichia ruminantium (strain Welgevonden)")"Ehrlichia ruminantium")"Ehrlichia", ("Neorickettsia risticii (strain Illinois)", "Neorickettsia sennetsu (strain ATCC VR-367 / Miyayama)")"Neorickettsia", ("Wolbachia sp. subsp. Brugia malayi (strain TRS)", "Wolbachia pipientis subsp. Culex pipiens (strain wPip)", "Wolbachia pipientis wMel", "Wolbachia sp. subsp. Drosophila simulans (strain wRi)")"Wolbachia")"Anaplasmataceae", "Midichloria mitochondrii (strain IricVA)", (("Orientia tsutsugamushi (strain Boryong)", "Orientia tsutsugamushi (strain Ikeda)")"Orientia tsutsugamushi", ("Rickettsia africae (strain ESF-5)", "Rickettsia akari (strain Hartford)", "Rickettsia amblyommatis (strain GAT-30V)", "Rickettsia australis (strain Cutlack)", ("Rickettsia bellii (strain OSU 85-389)", "Rickettsia bellii (strain RML369-C)")"Rickettsia bellii", "Rickettsia canadensis (strain McKiel)", "Rickettsia conorii (strain ATCC VR-613 / Malish 7)", "Rickettsia felis (strain ATCC VR-1525 / URRWXCal2)", "Rickettsia japonica (strain ATCC VR-1363 / YH)", "Rickettsia massiliae (strain Mtu5)", "Rickettsia montanensis (strain OSU 85-930)", "Rickettsia parkeri (strain Portsmouth)", "Rickettsia peacockii (strain Rustic)", "Rickettsia philipii (strain 364D)", ("Rickettsia prowazekii (strain Madrid E)", "Rickettsia prowazekii (strain Rp22)")"Rickettsia prowazekii", "Rickettsia rhipicephali (strain 3-7-female6-CWPP)", ("Rickettsia rickettsii (strain Iowa)", "Rickettsia rickettsii (strain Sheila Smith)")"Rickettsia rickettsii", "Rickettsia slovaca (strain 13-B)", "Rickettsia typhi (strain ATCC VR-144 / Wilmington)")"Rickettsia")"Rickettsieae")"Rickettsiales", ("Erythrobacter litoralis (strain HTCC2594)", ("Novosphingobium aromaticivorans (strain ATCC 700278 / DSM 12444 / CIP 105152 / NBRC 16084 / F199)", "Sphingobium japonicum (strain NBRC 101211 / UT26S)", "Sphingomonas wittichii (strain RW1 / DSM 6014 / JCM 10273)", "Sphingopyxis alaskensis (strain DSM 13593 / LMG 18877 / RB2256)", (("Zymomonas mobilis subsp. mobilis (strain ATCC 10988 / DSM 424 / LMG 404 / NCIMB 8938 / NRRL B-806 / ZM1)", "Zymomonas mobilis subsp. mobilis (strain ATCC 31821 / ZM4 / CP4)", "Zymomonas mobilis subsp. mobilis (strain NCIMB 11163 / B70)")"Zymomonas mobilis subsp. mobilis", "Zymomonas mobilis subsp. pomaceae (strain ATCC 29192 / JCM 10191 / NBRC 13757 / NCIMB 11200 / NRRL B-4491)")"Zymomonas mobilis")"Sphingomonadaceae")"Sphingomonadales", ("Micavibrio aeruginosavorus (strain ARL-13)", "Polymorphum gilvum (strain LMG 25793 / CGMCC 1.9160 / SL003B-26A1)", "Puniceispirillum marinum (strain IMCC1322)")"unclassified Alphaproteobacteria")"Alphaproteobacteria", ((("Achromobacter xylosoxidans (strain A8)", "Advenella kashmirensis (strain DSM 17095 / LMG 22695 / WT001)", ("Bordetella avium (strain 197N)", ("Bordetella bronchiseptica (strain ATCC BAA-588 / NCTC 13252 / RB50)", "Bordetella bronchiseptica (strain MO149)")"Bordetella bronchiseptica", "Bordetella parapertussis (strain 12822 / ATCC BAA-587 / NCTC 13253)", ("Bordetella pertussis (strain ATCC 9797 / DSM 5571 / NCTC 10739 / 18323)", "Bordetella pertussis (strain CS)", "Bordetella pertussis (strain Tohama I / ATCC BAA-589 / NCTC 13251)")"Bordetella pertussis", "Bordetella petrii (strain ATCC BAA-461 / DSM 12804 / CCUG 43448)")"Bordetella", "Pusillimonas sp. (strain T7-7)", "Taylorella equigenitalis (strain MCE9)")"Alcaligenaceae", (((("Burkholderia ambifaria (strain ATCC BAA-244 / AMMD)", "Burkholderia ambifaria (strain MC40-6)")"Burkholderia ambifaria", ("Burkholderia cenocepacia (strain ATCC BAA-245 / DSM 16553 / LMG 16656 / NCTC 13227 / J2315 / CF5610)", "Burkholderia cenocepacia (strain AU 1054)", "Burkholderia cenocepacia (strain HI2424)", "Burkholderia cenocepacia (strain MC0-3)")"Burkholderia cenocepacia", "Burkholderia lata (strain ATCC 17760 / LMG 22485 / NCIMB 9086 / R18194 / 383)", "Burkholderia multivorans (strain ATCC 17616 / 249)", "Burkholderia vietnamiensis (strain G4 / LMG 22486)")"Burkholderia cepacia complex", "Burkholderia gladioli (strain BSR3)", "Burkholderia glumae (strain BGR1)", ("Burkholderia mallei (strain ATCC 23344)", "Burkholderia mallei (strain NCTC 10229)", "Burkholderia mallei (strain NCTC 10247)", "Burkholderia mallei (strain SAVP1)")"Burkholderia mallei", ("Burkholderia pseudomallei (strain 1106a)", "Burkholderia pseudomallei (strain 1710b)", "Burkholderia pseudomallei (strain 668)", "Burkholderia pseudomallei (strain K96243)")"Burkholderia pseudomallei", "Burkholderia sp. (strain CCGE1002)", "Burkholderia sp. (strain CCGE1003)", "Burkholderia thailandensis (strain ATCC 700388 / DSM 13276 / CIP 106301 / E264)")"Burkholderia", ("Cupriavidus metallidurans (strain ATCC 43123 / DSM 2839 / NBRC 102507 / CH34)", ("Cupriavidus necator (strain ATCC 17699 / H16 / DSM 428 / Stanier 337)", "Cupriavidus necator (strain ATCC 43291 / DSM 13513 / N-1)")"Cupriavidus necator", "Cupriavidus necator (strain JMP 134 / LMG 1197)", "Cupriavidus taiwanensis (strain DSM 17343 / BCRC 17206 / CIP 107171 / LMG 19424 / R1)")"Cupriavidus", ("Paraburkholderia phymatum (strain DSM 17167 / CIP 108236 / LMG 21445 / STM815)", "Paraburkholderia phytofirmans (strain DSM 17436 / LMG 22146 / PsJN)", "Paraburkholderia rhizoxinica (strain DSM 19002 / CIP 109453 / HKI 454)", "Paraburkholderia xenovorans (strain LB400)")"Paraburkholderia", ("Polynucleobacter asymbioticus (strain DSM 18221 / CIP 109841 / QLW-P1DMWA-1)", "Polynucleobacter necessarius subsp. necessarius (strain STIR1)")"Polynucleobacter", (("Ralstonia pickettii (strain 12D)", "Ralstonia pickettii (strain 12J)")"Ralstonia pickettii", (RALSL, "Ralstonia solanacearum (strain GMI1000)", "Ralstonia solanacearum (strain Po82)")"Ralstonia solanacearum")"Ralstonia")"Burkholderiaceae", (("Acidovorax avenae (strain ATCC 19860 / DSM 7227 / JCM 20985 / NCPPB 1011)", "Acidovorax citrulli (strain AAC00-1)", "Acidovorax ebreus (strain TPSY)", "Acidovorax sp. (strain JS42)")"Acidovorax", "Alicycliphilus denitrificans (strain DSM 14773 / CIP 107495 / K601)", "Comamonas testosteroni (strain CNB-2)", ("Delftia acidovorans (strain DSM 14801 / SPH-1)", "Delftia sp. (strain Cs1-4)")"Delftia", ("Polaromonas naphthalenivorans (strain CJ2)", "Polaromonas sp. (strain JS666 / ATCC BAA-500)")"Polaromonas", "Ramlibacter tataouinensis (strain ATCC BAA-407 / DSM 14655 / LMG 21543 / TTB310)", "Rhodoferax ferrireducens (strain ATCC BAA-621 / DSM 15236 / T118)", ("Variovorax paradoxus (strain EPS)", "Variovorax paradoxus (strain S110)")"Variovorax paradoxus", "Verminephrobacter eiseniae (strain EF01-2)")"Comamonadaceae", ("Zinderia insecticola (strain CARI)", "Collimonas fungivorans (strain Ter331)", "Herbaspirillum seropedicae (strain SmR1)", "Herminiimonas arsenicoxydans", "Janthinobacterium sp. (strain Marseille)")"Oxalobacteraceae", ("Leptothrix cholodnii (strain ATCC 51168 / LMG 8142 / SP-6)", "Methylibium petroleiphilum (strain ATCC BAA-1232 / LMG 22953 / PM1)", "Rubrivivax gelatinosus (strain NBRC 100245 / IL144)", "Thiomonas intermedia (strain K12)")"Burkholderiales Genera incertae sedis")"Burkholderiales", (("Chromobacterium violaceum (strain ATCC 12472 / DSM 30191 / JCM 1249 / NBRC 12614 / NCIMB 9131 / NCTC 9757)", "Laribacter hongkongensis (strain HLHK9)", "Pseudogulbenkiania sp. (strain NH8B)")"Chromobacteriaceae", (("Neisseria gonorrhoeae (strain ATCC 700825 / FA 1090)", "Neisseria gonorrhoeae (strain NCCP11945)")"Neisseria gonorrhoeae", ("Neisseria meningitidis (strain alpha14)", "Neisseria meningitidis serogroup A / serotype 4A (strain Z2491)", "Neisseria meningitidis serogroup A (strain WUE 2594)", ("Neisseria meningitidis serogroup B (strain MC58)", "Neisseria meningitidis serogroup B (strain alpha710)", "Neisseria meningitidis serogroup B / serotype 15 (strain H44/76)")"Neisseria meningitidis serogroup B", "Neisseria meningitidis serogroup B (strain G2136)", "Neisseria meningitidis serogroup B (strain M01-240149)", "Neisseria meningitidis serogroup B (strain M01-240355)", "Neisseria meningitidis serogroup B (strain M04-240196)", "Neisseria meningitidis serogroup B (strain NZ-05/33)", ("Neisseria meningitidis serogroup C (strain 053442)", "Neisseria meningitidis serogroup C (strain 8013)", "Neisseria meningitidis serogroup C / serotype 2a (strain ATCC 700532 / DSM 15464 / FAM18)")"Neisseria meningitidis serogroup C")"Neisseria meningitidis")"Neisseria")"Neisseriales", (("Gallionella capsiferriformans (strain ES-2)", "Sideroxydans lithotrophicus (strain ES-1)")"Gallionellaceae", ("Methylobacillus flagellatus (strain KT / ATCC 51484 / DSM 6875)", "Methylotenera mobilis (strain JLW8 / ATCC BAA-1282 / DSM 17540)", ("Methylovorus glucosetrophus (strain SIP3-4)", "Methylovorus sp. (strain MP688)")"Methylovorus")"Methylophilaceae", (("Nitrosomonas europaea (strain ATCC 19718 / CIP 103999 / KCTC 2705 / NBRC 14298)", "Nitrosomonas eutropha (strain C91)", "Nitrosomonas sp. (strain Is79A3)")"Nitrosomonas", "Nitrosospira multiformis (strain ATCC 25196 / NCIMB 11849 / C 71)")"Nitrosomonadaceae", "Thiobacillus denitrificans (strain ATCC 25259)")"Nitrosomonadales", ("Dechloromonas aromatica (strain RCB)", ("Aromatoleum aromaticum (strain EbN1)", "Dechlorosoma suillum (strain ATCC BAA-33 / DSM 13638 / PS)")"Rhodocyclaceae", ("Azoarcus sp. (strain BH72)", "Thauera sp. (strain MZ1T)")"Zoogloeaceae")"Rhodocyclales", ("Accumulibacter phosphatis (strain UW-1)", "Tremblaya princeps (strain PCIT)")"unclassified Betaproteobacteria")"Betaproteobacteria", ((("Aeromonas hydrophila subsp. hydrophila (strain ATCC 7966 / DSM 30187 / JCM 1027 / KCTC 2358 / NCIMB 9240)", "Aeromonas salmonicida (strain A449)", "Aeromonas veronii (strain B565)")"Aeromonas", "Oceanimonas sp. (strain GK1)", "Tolumonas auensis (strain DSM 9187 / TA4)")"Aeromonadaceae", (((("Alteromonas macleodii (strain Balearic Sea AD45)", "Alteromonas macleodii (strain Black Sea 11)", "Alteromonas macleodii (strain English Channel 673)")"Alteromonas macleodii", "Alteromonas mediterranea (strain DSM 17117 / CIP 110805 / LMG 28347 / Deep ecotype)", "Alteromonas naphthalenivorans")"Alteromonas", ("Marinobacter adhaerens (strain HP15)", "Marinobacter hydrocarbonoclasticus (strain ATCC 700491 / DSM 11845 / VT8)")"Marinobacter")"Alteromonadaceae", "Colwellia psychrerythraea (strain 34H / ATCC BAA-681)", "Ferrimonas balearica (strain DSM 9799 / CCM 4581 / PAT)", "Idiomarina loihiensis (strain ATCC BAA-735 / DSM 15497 / L2-TR)", ("Pseudoalteromonas atlantica (strain T6c / ATCC BAA-1087)", "Pseudoalteromonas haloplanktis (strain TAC 125)", "Pseudoalteromonas sp. (strain SM9913)")"Pseudoalteromonas", "Psychromonas ingrahamii (strain 37)", ("Shewanella amazonensis (strain ATCC BAA-1098 / SB2B)", ("Shewanella baltica (strain OS155 / ATCC BAA-1091)", "Shewanella baltica (strain OS185)", "Shewanella baltica (strain OS195)", "Shewanella baltica (strain OS223)", "Shewanella baltica (strain OS678)")"Shewanella baltica", "Shewanella denitrificans (strain OS217 / ATCC BAA-1090 / DSM 15013)", "Shewanella frigidimarina (strain NCIMB 400)", "Shewanella halifaxensis (strain HAW-EB4)", "Shewanella loihica (strain ATCC BAA-1088 / PV-4)", "Shewanella oneidensis (strain MR-1)", "Shewanella pealeana (strain ATCC 700345 / ANG-SQ1)", "Shewanella piezotolerans (strain WP3 / JCM 13877)", ("Shewanella putrefaciens (strain 200)", "Shewanella putrefaciens (strain CN-32 / ATCC BAA-453)")"Shewanella putrefaciens", "Shewanella sediminis (strain HAW-EB3)", "Shewanella sp. (strain ANA-3)", "Shewanella sp. (strain MR-4)", "Shewanella sp. (strain MR-7)", "Shewanella sp. (strain W3-18-1)", "Shewanella violacea (strain JCM 10179 / CIP 106290 / LMG 19151 / DSS12)", "Shewanella woodyi (strain ATCC 51908 / MS32)")"Shewanella")"Alteromonadales", "Dichelobacter nodosus (strain VCS1703A)", ("Cellvibrio japonicus (strain Ueda107)", "Saccharophagus degradans (strain 2-40 / ATCC 43961 / DSM 17024)", "Simiduia agarivorans (strain DSM 21679 / JCM 13881 / BCRC 17597 / SA1)", "Teredinibacter turnerae (strain ATCC 39867 / T7901)")"Cellvibrionaceae", (("Allochromatium vinosum (strain ATCC 17899 / DSM 180 / NBRC 103801 / NCIMB 10441 / D)", ("Nitrosococcus halophilus (strain Nc4)", "Nitrosococcus oceani (strain ATCC 19707 / BCRC 17464 / NCIMB 11848 / C-107)", "Nitrosococcus watsoni (strain C-113)")"Nitrosococcus", "Thiocystis violascens (strain ATCC 17096 / DSM 198 / 6111)")"Chromatiaceae", ("Alkalilimnicola ehrlichii (strain ATCC BAA-1101 / DSM 17681 / MLHE-1)", "Halorhodospira halophila (strain DSM 244 / SL1)", ("Thioalkalivibrio sp. (strain K90mix)", "Thioalkalivibrio sulfidiphilus (strain HL-EbGR7)")"Thioalkalivibrio")"Ectothiorhodospiraceae", "Halothiobacillus neapolitanus (strain ATCC 23641 / c2)")"Chromatiales", (("Moranella endobia (strain PCIT)", "Riesia pediculicola (strain USDA)", ("Citrobacter koseri (strain ATCC BAA-895 / CDC 4225-83 / SGSC4696)", "Citrobacter rodentium (strain ICC168)")"Citrobacter", ("Cronobacter sakazakii (strain ATCC BAA-894)", "Cronobacter turicensis (strain DSM 18703 / LMG 23827 / z3032)")"Cronobacter", (("Enterobacter asburiae (strain LF7a)", "Enterobacter cloacae subsp. cloacae (strain ATCC 13047 / DSM 30054 / NBRC 13535 / NCDC 279-56)", "Enterobacter lignolyticus (strain SCF1)")"Enterobacter cloacae complex", "Enterobacter sp. (strain 638)")"Enterobacter", ((ECOLX, "Escherichia coli (strain \'clone D i14\')", "Escherichia coli (strain \'clone D i2\')", "Escherichia coli (strain 55989 / EAEC)", "Escherichia coli (strain ATCC 33849 / DSM 4235 / NCIB 12045 / K12 / DH1)", "Escherichia coli (strain ATCC 55124 / KO11FL)", "Escherichia coli (strain ATCC 9637 / CCM 2024 / DSM 1116 / NCIMB 8666 / NRRL B-766 / W)", "Escherichia coli (strain B / BL21)", "Escherichia coli (strain B / BL21-DE3)", (ECOLI, "Escherichia coli (strain K12 / DH10B)", "Escherichia coli (strain K12 / MC4100 / BW2952)")"Escherichia coli (strain K12)", "Escherichia coli (strain SE11)", "Escherichia coli (strain SMS-3-5 / SECEC)", "Escherichia coli (strain UM146)", "Escherichia coli (strain UTI89 / UPEC)", "Escherichia coli (strain B / REL606)", "Escherichia coli (strain ATCC 8739 / DSM 1576 / Crooks)", "Escherichia coli O103:H2 (strain 12009 / EHEC)", "Escherichia coli O104:H4 (strain 2009EL-2071)", "Escherichia coli O111:H- (strain 11128 / EHEC)", "Escherichia coli O127:H6 (strain E2348/69 / EPEC)", "Escherichia coli O139:H28 (strain E24377A / ETEC)", "Escherichia coli O150:H5 (strain SE15)", (ECO57, "Escherichia coli O157:H7 (strain EC4115 / EHEC)", "Escherichia coli O157:H7 (strain TW14359 / EHEC)")"Escherichia coli O157:H7", "Escherichia coli O17:K52:H18 (strain UMN026 / ExPEC)", "Escherichia coli O18:K1:H7 (strain IHE3034 / ExPEC)", "Escherichia coli O1:K1 / APEC", "Escherichia coli O26:H11 (strain 11368 / EHEC)", "Escherichia coli O44:H18 (strain 042 / EAEC)", "Escherichia coli O45:K1 (strain S88 / ExPEC)", "Escherichia coli O55:H7 (strain CB9615 / EPEC)", "Escherichia coli O6:H1 (strain CFT073 / ATCC 700928 / UPEC)", "Escherichia coli O6:K15:H31 (strain 536 / UPEC)", "Escherichia coli O78:H11 (strain H10407 / ETEC)", "Escherichia coli O7:K1 (strain IAI39 / ExPEC)", "Escherichia coli O8 (strain IAI1)", "Escherichia coli O81 (strain ED1a)", "Escherichia coli O83:H1 (strain NRG 857C / AIEC)", "Escherichia coli O9:H4 (strain HS)", "Escherichia coli OR:K5:H- (strain ABU 83972)")"Escherichia coli", "Escherichia fergusonii (strain ATCC 35469 / DSM 13698 / CDC 0568-73)")"Escherichia", ("Klebsiella aerogenes (strain ATCC 13048 / DSM 30053 / JCM 1235 / KCTC 2190 / NBRC 13534 / NCIMB 10102 / NCTC 10006)", "Klebsiella oxytoca (strain ATCC 8724 / DSM 4798 / JCM 20051 / NBRC 3318 / NRRL B-199 / KCTC 1686)", ("Klebsiella pneumoniae (strain 342)", ("Klebsiella pneumoniae subsp. pneumoniae (strain ATCC 700721 / MGH 78578)", "Klebsiella pneumoniae subsp. pneumoniae (strain HS11286)")"Klebsiella pneumoniae subsp. pneumoniae")"Klebsiella pneumoniae", "Klebsiella variicola (strain At-22)")"Klebsiella", ("Salmonella bongori (strain ATCC 43975 / DSM 13772 / NCTC 12419)", (("Salmonella dublin (strain CT_02021853)", "Salmonella agona (strain SL483)", "Salmonella choleraesuis (strain SC-B67)", "Salmonella pullorum (strain RKS5078 / SGSC2294)", "Salmonella heidelberg (strain SL476)", "Salmonella paratyphi B (strain ATCC BAA-1250 / SPB7)", "Salmonella paratyphi C (strain RKS4594)", "Salmonella schwarzengrund (strain CVM19633)", "Salmonella enteritidis PT4 (strain P125109)", "Salmonella gallinarum (strain 287/91 / NCTC 13346)", "Salmonella newport (strain SL254)", ("Salmonella paratyphi A (strain AKU_12601)", "Salmonella paratyphi A (strain ATCC 9150 / SARB42)")"Salmonella paratyphi A", "Salmonella typhi", ("Salmonella typhimurium (strain 4/74)", "Salmonella typhimurium (strain D23580)", (SALTY, "Salmonella typhimurium (strain 14028s / SGSC 2262)")"Salmonella typhimurium (strain LT2 / SGSC1412 / ATCC 700720)", "Salmonella typhimurium (strain SL1344)")"Salmonella typhimurium")"Salmonella enterica I", "Salmonella arizonae (strain ATCC BAA-731 / CDC346-86 / RSK2980)")"Salmonella choleraesuis")"Salmonella", (("Shigella boydii serotype 18 (strain CDC 3083-94 / BS512)", "Shigella boydii serotype 4 (strain Sb227)")"Shigella boydii", "Shigella dysenteriae serotype 1 (strain Sd197)", (SHIFL, "Shigella flexneri serotype 5b (strain 8401)", "Shigella flexneri serotype X (strain 2002017)")"Shigella flexneri", "Shigella sonnei (strain Ss046)")"Shigella", "Shimwellia blattae (strain ATCC 29907 / DSM 4481 / JCM 1650 / NBRC 105725 / CDC 9005-74)", ((("Blochmannia floridanus", "Blochmannia pennsylvanicus (strain BPEN)", "Blochmannia vafer (strain BVAF)")"Candidatus Blochmannia", "Hamiltonella defensa subsp. Acyrthosiphon pisum (strain 5AT)")"ant, tsetse, mealybug, aphid, etc. endosymbionts", "Enterobacteriaceae bacterium (strain FGI 57)")"unclassified Enterobacteriaceae")"Enterobacteriaceae", ((((BUCAI, "Buchnera aphidicola subsp. Acyrthosiphon pisum (strain 5A)")"Buchnera aphidicola subsp. Acyrthosiphon pisum (strain APS)", "Buchnera aphidicola subsp. Acyrthosiphon pisum (strain JF98)", "Buchnera aphidicola subsp. Acyrthosiphon pisum (strain JF99)", "Buchnera aphidicola subsp. Acyrthosiphon pisum (strain LL01)", "Buchnera aphidicola subsp. Acyrthosiphon pisum (strain Tuc7)")"Buchnera aphidicola (Acyrthosiphon pisum)", "Buchnera aphidicola subsp. Baizongia pistaciae (strain Bp)", "Buchnera aphidicola subsp. Cinara cedri (strain Cc)", "Buchnera aphidicola subsp. Schizaphis graminum (strain Sg)")"Buchnera aphidicola", (("Erwinia amylovora (strain ATCC 49946 / CCPPB 0273 / Ea273 / 27-3)", "Erwinia amylovora (strain CFBP1430)")"Erwinia amylovora", "Erwinia billingiae (strain Eb661)", ("Erwinia pyrifoliae (strain DSM 12163 / CIP 106111 / Ep16/96)", "Erwinia pyrifoliae (strain Ep1/96)")"Erwinia pyrifoliae", "Erwinia sp. (strain Ejp617)", "Erwinia tasmaniensis (strain DSM 17950 / CIP 109463 / Et1/99)")"Erwinia", (("Pantoea ananatis (strain AJ13355)", "Pantoea ananatis (strain LMG 20103)")"Pantoea ananas", "Pantoea sp. (strain At-9b)", "Pantoea vagans (strain C9-1)")"Pantoea", "Wigglesworthia glossinidia brevipalpis")"Erwiniaceae", ("Edwardsiella ictaluri (strain 93-146)", ("Edwardsiella tarda (strain EIB202)", "Edwardsiella tarda (strain FL6-60)")"Edwardsiella tarda")"Edwardsiella", (("Photorhabdus asymbiotica subsp. asymbiotica (strain ATCC 43949 / 3105-77)", "Photorhabdus luminescens subsp. laumondii (strain DSM 15139 / CIP 105565 / TT01)")"Photorhabdus", "Proteus mirabilis (strain HI4320)", "Providencia stuartii (strain MRSN 2154)", ("Xenorhabdus bovienii (strain SS-2004)", "Xenorhabdus nematophila (strain ATCC 19061 / DSM 3370 / LMG 1036 / NCIB 9965 / AN6)")"Xenorhabdus")"Morganellaceae", (("Dickeya chrysanthemi (strain Ech1591)", "Dickeya dadantii (strain 3937)", "Dickeya paradisiaca (strain Ech703)", "Dickeya zeae (strain Ech586)")"Dickeya", ("Pectobacterium atrosepticum (strain SCRI 1043 / ATCC BAA-672)", "Pectobacterium carotovorum subsp. carotovorum (strain PC1)", "Pectobacterium parmentieri (strain WPP163)", "Pectobacterium sp. (strain SCC3193)")"Pectobacterium", "Sodalis glossinidius (strain morsitans)")"Pectobacteriaceae", (("Rahnella aquatilis (strain ATCC 33071 / DSM 4594 / JCM 1683 / NBRC 105701 / NCIMB 13365 / CIP 78.65)", "Rahnella sp. (strain Y9602)")"Rahnella", ("Serratia fonticola", "Serratia plymuthica (strain AS9)", "Serratia proteamaculans (strain 568)")"Serratia", (("Yersinia enterocolitica serotype O:8 / biotype 1B (strain NCTC 13174 / 8081)", ("Yersinia enterocolitica subsp. palearctica serotype O:3 (strain DSM 13030 / CIP 106945 / Y11)", "Yersinia enterocolitica subsp. palearctica serotype O:9 / biotype 3 (strain 105.5R(r))")"Yersinia enterocolitica subsp. palearctica")"Yersinia enterocolitica", ((YERPE, "Yersinia pestis (strain D106004)", "Yersinia pestis (strain D182038)", "Yersinia pestis (strain Pestoides F)", "Yersinia pestis (strain Z176003)", "Yersinia pestis bv. Antiqua (strain Angola)", "Yersinia pestis bv. Antiqua (strain Antiqua)", "Yersinia pestis bv. Antiqua (strain Nepal516)", "Yersinia pestis bv. Medievalis (strain Harbin 35)")"Yersinia pestis", ("Yersinia pseudotuberculosis serotype I (strain IP32953)", "Yersinia pseudotuberculosis serotype IB (strain PB1/+)", "Yersinia pseudotuberculosis serotype O:1b (strain IP 31758)", "Yersinia pseudotuberculosis serotype O:3 (strain YPIII)")"Yersinia pseudotuberculosis")"Yersinia pseudotuberculosis complex")"Yersinia")"Yersiniaceae")"Enterobacterales", (("Coxiella burnetii (strain CbuG_Q212)", "Coxiella burnetii (strain CbuK_Q154)", "Coxiella burnetii (strain Dugway 5J108-111)", "Coxiella burnetii (strain RSA 331 / Henzerling II)", "Coxiella burnetii (strain RSA 493 / Nine Mile phase I)")"Coxiella burnetii", (("Legionella longbeachae serogroup 1 (strain NSW150)", ("Legionella pneumophila (strain Corby)", "Legionella pneumophila (strain Lens)", "Legionella pneumophila (strain Paris)", "Legionella pneumophila serogroup 1 (strain 2300/99 Alcoy)", "Legionella pneumophila subsp. pneumophila (strain Philadelphia 1 / ATCC 33152 / DSM 7513)")"Legionella pneumophila")"Legionella", "Tatlockia micdadei")"Legionellaceae")"Legionellales", ("Methylococcus capsulatus (strain ATCC 33009 / NCIMB 11132 / Bath)", (METAA, "Methylomicrobium alcaliphilum (strain DSM 19304 / NCIMB 14124 / VKM B-2133 / 20Z)")"Methylomicrobium alcaliphilum", "Methylomonas methanica (strain MC09)")"Methylococcaceae", (("Alcanivorax borkumensis (strain ATCC 700651 / DSM 11573 / NCIMB 13689 / SK2)", "Alcanivorax dieselolei (strain DSM 16502 / CGMCC 1.3690 / B-5)")"Alcanivorax", "Hahella chejuensis (strain KCTC 2396)", ("Carsonella ruddii (strain PV)", "Chromohalobacter salexigens (strain DSM 3043 / ATCC BAA-138 / NCIMB 13768)", "Halomonas elongata (strain ATCC 33173 / DSM 2581 / NBRC 15536 / NCIMB 2198 / 1H9)")"Halomonadaceae", "Kangiella koreensis (strain DSM 16069 / KCTC 12182 / SW-125)", (("Marinomonas mediterranea (strain ATCC 700492 / JCM 21426 / NBRC 103028 / MMB-1)", "Marinomonas sp. (strain MWYL1)")"Marinomonas", "Neptuniibacter caesariensis")"Oceanospirillaceae")"Oceanospirillales", ((("Actinobacillus pleuropneumoniae serotype 3 (strain JL03)", "Actinobacillus pleuropneumoniae serotype 5b (strain L20)", "Actinobacillus pleuropneumoniae serotype 7 (strain AP76)")"Actinobacillus pleuropneumoniae", "Actinobacillus succinogenes (strain ATCC 55618 / 130Z)")"Actinobacillus", ("Aggregatibacter actinomycetemcomitans serotype C (strain D11S-1)", "Aggregatibacter aphrophilus (strain NJ8700)")"Aggregatibacter", "Mannheimia succiniciproducens (strain MBEL55E)", "Gallibacterium anatis (strain UMN179)", ("Haemophilus ducreyi (strain 35000HP / ATCC 700724)", ("Haemophilus influenzae (strain 10810)", "Haemophilus influenzae (strain 86-028NP)", "Haemophilus influenzae (strain ATCC 51907 / DSM 11121 / KW20 / Rd)", "Haemophilus influenzae (strain PittEE)", "Haemophilus influenzae (strain PittGG)", "Haemophilus influenzae (strain R2846 / 12)", "Haemophilus influenzae (strain R2866)")"Haemophilus influenzae", "Haemophilus parainfluenzae (strain T3T1)", "Haemophilus parasuis serovar 5 (strain SH0165)")"Haemophilus", ("Haemophilus somnus (strain 129Pt)", "Histophilus somni (strain 2336)")"Histophilus somni", ("Pasteurella multocida (strain HN06)", "Pasteurella multocida (strain Pm70)")"Pasteurella multocida subsp. multocida")"Pasteurellaceae", ((("Acinetobacter baylyi (strain ATCC 33305 / BD413 / ADP1)", (("Acinetobacter baumannii (strain 1656-2)", "Acinetobacter baumannii (strain AB0057)", "Acinetobacter baumannii (strain AB307-0294)", "Acinetobacter baumannii (strain ACICU)", "Acinetobacter baumannii (strain ATCC 17978 / CIP 53.77 / LMG 1025 / NCDC KC755 / 5377)", "Acinetobacter baumannii (strain AYE)", "Acinetobacter baumannii (strain SDF)", "Acinetobacter baumannii (strain TCDC-AB0715)")"Acinetobacter baumannii", "Acinetobacter calcoaceticus (strain PHEA-2)")"Acinetobacter calcoaceticus/baumannii complex", "Acinetobacter oleivorans (strain JCM 16667 / KCTC 23045 / DR1)")"Acinetobacter", "Moraxella catarrhalis (strain RH4)", ("Psychrobacter arcticus (strain DSM 17307 / 273-4)", "Psychrobacter cryohalolentis (strain K5)", "Psychrobacter sp. (strain PRwf-1)")"Psychrobacter")"Moraxellaceae", ("Azotobacter vinelandii (strain DJ / ATCC BAA-1303)", (("Pseudomonas aeruginosa (strain ATCC 15692 / DSM 22644 / CIP 104116 / JCM 14847 / LMG 12228 / 1C / PRS 101 / PAO1)", "Pseudomonas aeruginosa (strain LESB58)", "Pseudomonas aeruginosa (strain PA7)", "Pseudomonas aeruginosa (strain UCBPP-PA14)")"Pseudomonas aeruginosa", "Pseudomonas brassicacearum (strain NFM421)", "Pseudomonas entomophila (strain L48)", ("Pseudomonas fluorescens (strain Pf0-1)", "Pseudomonas fluorescens (strain SBW25)")"Pseudomonas fluorescens", "Pseudomonas fulva (strain 12-X)", ("Pseudomonas mendocina (strain NK-01)", "Pseudomonas mendocina (strain ymp)")"Pseudomonas mendocina", "Pseudomonas fluorescens (strain ATCC BAA-477 / NRRL B-23932 / Pf-5)", ("Pseudomonas putida (strain ATCC 47054 / DSM 6125 / NCIMB 11950 / KT2440)", "Pseudomonas putida (strain ATCC 700007 / DSM 6899 / BCRC 17059 / F1)", "Pseudomonas putida (strain BIRD-1)", "Pseudomonas putida (strain GB-1)", "Pseudomonas putida (strain W619)")"Pseudomonas putida", "Pseudomonas savastanoi pv. phaseolicola (strain 1448A / Race 6)", ("Pseudomonas stutzeri (strain A1501)", "Pseudomonas stutzeri (strain ATCC 17588 / DSM 5190 / CCUG 11256 / JCM 5965 / LMG 11199 / NCIMB 11358 / Stanier 221)")"Pseudomonas stutzeri", "Pseudomonas syringae pv. syringae (strain B728a)", "Pseudomonas syringae pv. tomato (strain ATCC BAA-871 / DC3000)")"Pseudomonas")"Pseudomonadaceae")"Pseudomonadales", (("Francisella noatunensis subsp. orientalis (strain Toba 04)", "Francisella philomiragia subsp. philomiragia (strain ATCC 25017)", (("Francisella cf. novicida (strain 3523)", "Francisella cf. novicida (strain Fx1)", "Francisella tularensis subsp. novicida (strain U112)")"Francisella novicida", ("Francisella tularensis subsp. holarctica (strain FTNF002-00 / FTA)", "Francisella tularensis subsp. holarctica (strain LVS)", "Francisella tularensis subsp. holarctica (strain OSU18)")"Francisella tularensis subsp. holarctica", "Francisella tularensis subsp. mediasiatica (strain FSC147)", ("Francisella tularensis subsp. tularensis (strain FSC 198)", "Francisella tularensis subsp. tularensis (strain NE061598)", "Francisella tularensis subsp. tularensis (strain SCHU S4 / Schu 4)", "Francisella tularensis subsp. tularensis (strain WY96-3418)")"Francisella tularensis subsp. tularensis")"Francisella tularensis")"Francisella", ("Cycloclasticus sp. (strain P1)", ("Methylophaga frappieri (strain ATCC BAA-2434 / DSM 25690 / JAM7)", "Methylophaga nitratireducenticrescens (strain ATCC BAA-2433 / DSM 25689 / JAM1)")"Methylophaga", "Thioalkalimicrobium cyclicum (strain DSM 14477 / JCM 11371 / ALM1)", "Thiomicrospira crunogena (strain XCL-2)")"Piscirickettsiaceae")"Thiotrichales", ((("Vibrio fischeri (strain ATCC 700601 / ES114)", "Vibrio fischeri (strain MJ11)")"Aliivibrio fischeri", "Aliivibrio salmonicida (strain LFI1238)")"Aliivibrio", "Photobacterium profundum (strain SS9)", ("Vibrio anguillarum (strain ATCC 68554 / 775)", "Vibrio antiquarius (strain Ex25)", "Vibrio campbellii (strain ATCC BAA-1116 / BB120)", (("Vibrio cholerae serotype O1 (strain ATCC 39315 / El Tor Inaba N16961)", "Vibrio cholerae serotype O1 (strain MJ-1236)")"Vibrio cholerae O1", "Vibrio cholerae serotype O1 (strain ATCC 39541 / Classical Ogawa 395 / O395)", "Vibrio cholerae serotype O1 (strain M66-2)")"Vibrio cholerae", "Vibrio furnissii (strain DSM 14383 / NCTC 11218)", "Vibrio parahaemolyticus serotype O3:K6 (strain RIMD 2210633)", "Vibrio tasmaniensis (strain LGP32)", ("Vibrio vulnificus (strain CMCP6)", "Vibrio vulnificus (strain MO6-24/O)", "Vibrio vulnificus (strain YJ016)")"Vibrio vulnificus")"Vibrio")"Vibrionaceae", ("Frateuria aurantia (strain ATCC 33424 / DSM 6220 / NBRC 3245 / NCIMB 13370)", ("Lysobacter enzymogenes", ("Pseudoxanthomonas spadix (strain BD-a59)", "Pseudoxanthomonas suwonensis (strain 11-1)")"Pseudoxanthomonas", ("Stenotrophomonas maltophilia (strain K279a)", "Stenotrophomonas maltophilia (strain R551-3)")"Stenotrophomonas maltophilia", ("Xanthomonas albilineans (strain GPE PC73 / CFBP 7063)", ("Xanthomonas campestris pv. campestris (strain 8004)", "Xanthomonas campestris pv. campestris (strain ATCC 33913 / DSM 3586 / NCPPB 528 / LMG 568 / P 25)", "Xanthomonas campestris pv. campestris (strain B100)")"Xanthomonas campestris pv. campestris", "Xanthomonas axonopodis pv. citri (strain 306)", "Xanthomonas campestris pv. vesicatoria (strain 85-10)", ("Xanthomonas oryzae pv. oryzae (strain KACC10331 / KXO85)", "Xanthomonas oryzae pv. oryzae (strain MAFF 311018)", "Xanthomonas oryzae pv. oryzae (strain PXO99A)")"Xanthomonas oryzae pv. oryzae")"Xanthomonas", ("Xylella fastidiosa (strain 9a5c)", "Xylella fastidiosa (strain M12)", "Xylella fastidiosa (strain M23)", "Xylella fastidiosa (strain Temecula1 / ATCC 700964)", "Xylella fastidiosa (strain GB514)")"Xylella fastidiosa")"Xanthomonadaceae")"Xanthomonadales", ("Baumannia cicadellinicola subsp. Homalodisca coagulata", ("Vesicomyosocius okutanii subsp. Calyptogena okutanii (strain HA)", "Ruthia magnifica subsp. Calyptogena magnifica")"sulfur-oxidizing symbionts")"unclassified Gammaproteobacteria")"Gammaproteobacteria", ((("Bdellovibrio bacteriovorus (strain ATCC 15356 / DSM 50701 / NCIB 9529 / HD100)", "Halobacteriovorax marinus (strain ATCC BAA-682 / DSM 15412 / SJ)")"Bdellovibrionales", "Desulfarculus baarsii (strain ATCC 33931 / DSM 2075 / VKM B-1802 / 2st14)", (("Desulfatibacillum alkenivorans (strain AK-01)", "Desulfobacterium autotrophicum (strain ATCC 43914 / DSM 3382 / HRM2)", "Desulfobacula toluolica (strain DSM 7467 / Tol2)", "Desulfococcus oleovorans (strain DSM 6200 / Hxd3)")"Desulfobacteraceae", ("Desulfobulbus propionicus (strain ATCC 33891 / DSM 2032 / 1pr3)", "Desulfocapsa sulfexigens (strain DSM 10523 / SB164P1)", "Desulfotalea psychrophila (strain LSv54 / DSM 12343)", "Desulfurivibrio alkaliphilus (strain DSM 19089 / UNIQEM U267 / AHT2)")"Desulfobulbaceae")"Desulfobacterales", ("Desulfohalobium retbaense (strain ATCC 49708 / DSM 5692 / JCM 16813 / HR100)", "Desulfomicrobium baculatum (strain DSM 4028 / VKM B-1378)", (("Desulfovibrio aespoeensis (strain ATCC 700646 / DSM 10631 / Aspo-2)", "Desulfovibrio alaskensis (strain G20)", "Desulfovibrio desulfuricans (strain ATCC 27774 / DSM 6949)", "Desulfovibrio magneticus (strain ATCC 700980 / DSM 13731 / RS-1)", "Desulfovibrio piezophilus (strain DSM 21447 / JCM 15486 / C1TLV30)", "Desulfovibrio salexigens (strain ATCC 14822 / DSM 2638 / NCIB 8403 / VKM B-1763)", ("Desulfovibrio vulgaris (strain Hildenborough / ATCC 29579 / DSM 644 / NCIMB 8303)", "Desulfovibrio vulgaris (strain Miyazaki F / DSM 19637)", "Desulfovibrio vulgaris (strain RCH1)", "Desulfovibrio vulgaris subsp. vulgaris (strain DP4)")"Desulfovibrio vulgaris")"Desulfovibrio", "Lawsonia intracellularis (strain PHE/MN1-00)")"Desulfovibrionaceae")"Desulfovibrionales", "Hippea maritima (strain ATCC 700847 / DSM 10411 / MH2)", (("Pelobacter carbinolicus (strain DSM 2380 / NBRC 103641 / GraBd1)", "Pelobacter propionicus (strain DSM 2379 / NBRC 103807 / OttBd1)")"Pelobacter", ("Geobacter bemidjiensis (strain Bem / ATCC BAA-1014 / DSM 16622)", "Geobacter daltonii (strain DSM 22248 / JCM 15807 / FRC-32)", "Geobacter lovleyi (strain ATCC BAA-1151 / DSM 17278 / SZ)", "Geobacter metallireducens (strain GS-15 / ATCC 53774 / DSM 7210)", "Geobacter sp. (strain M18)", "Geobacter sp. (strain M21)", ("Geobacter sulfurreducens (strain ATCC 51573 / DSM 12127 / PCA)", "Geobacter sulfurreducens (strain DL-1 / KN400)")"Geobacter sulfurreducens", "Geobacter uraniireducens (strain Rf4)")"Geobacter")"Desulfuromonadales", (((("Anaeromyxobacter dehalogenans (strain 2CP-1 / ATCC BAA-258)", "Anaeromyxobacter dehalogenans (strain 2CP-C)")"Anaeromyxobacter dehalogenans", "Anaeromyxobacter sp. (strain Fw109-5)", "Anaeromyxobacter sp. (strain K)")"Anaeromyxobacter", "Stigmatella aurantiaca (strain DW4/3-1)", ("Corallococcus coralloides (strain ATCC 25202 / DSM 2259 / NBRC 100086 / M2)", ("Myxococcus fulvus (strain ATCC BAA-855 / HW-1)", "Myxococcus stipitatus (strain DSM 14675 / JCM 12634 / Mx s8)", "Myxococcus xanthus (strain DK 1622)")"Myxococcus")"Myxococcaceae")"Cystobacterineae", "Haliangium ochraceum (strain DSM 14365 / JCM 11303 / SMP-2)", "Sorangium cellulosum (strain So ce56)")"Myxococcales", (("Desulfobacca acetoxidans (strain ATCC 700848 / DSM 11109 / ASRB2)", "Desulfomonile tiedjei (strain ATCC 49306 / DSM 6799 / DCB-1)", "Syntrophus aciditrophicus (strain SB)")"Syntrophaceae", "Syntrophobacter fumaroxidans (strain DSM 10017 / MPOB)")"Syntrophobacterales")"Deltaproteobacteria", (((("Arcobacter butzleri (strain RM4018)", "Arcobacter nitrofigilis (strain ATCC 33309 / DSM 7299 / LMG 7604 / NCTC 12251 / CI)")"Arcobacter", ("Campylobacter concisus (strain 13826)", "Campylobacter curvus (strain 525.92)", "Campylobacter fetus subsp. fetus (strain 82-40)", "Campylobacter hominis (strain ATCC BAA-381 / LMG 19568 / NCTC 13146 / CH001A)", ("Campylobacter jejuni (strain RM1221)", "Campylobacter jejuni subsp. doylei (strain ATCC BAA-1458 / RM4099 / 269.97)", ("Campylobacter jejuni subsp. jejuni (strain IA3902)", "Campylobacter jejuni subsp. jejuni (strain S3)", "Campylobacter jejuni subsp. jejuni serotype HS21 (strain M1 / 99/308)", "Campylobacter jejuni subsp. jejuni serotype HS:41 (strain ICDCCJ07001)", "Campylobacter jejuni subsp. jejuni serotype O:2 (strain ATCC 700819 / NCTC 11168)", "Campylobacter jejuni subsp. jejuni serotype O:23/36 (strain 81-176)", "Campylobacter jejuni subsp. jejuni serotype O:6 (strain 81116 / NCTC 11828)")"Campylobacter jejuni subsp. jejuni")"Campylobacter jejuni", "Campylobacter lari (strain RM2100 / D67 / ATCC BAA-1060)")"Campylobacter", ("Sulfurospirillum barnesii (strain ATCC 700032 / DSM 10660 / SES-3)", "Sulfurospirillum deleyianum (strain ATCC 51133 / DSM 6946 / 5175)")"Sulfurospirillum")"Campylobacteraceae", (("Helicobacter acinonychis (strain Sheeba)", "Helicobacter bizzozeronii (strain CIII-1)", "Helicobacter cinaedi (strain PAGU611)", "Helicobacter felis (strain ATCC 49179 / NCTC 12436 / CS1)", "Helicobacter hepaticus (strain ATCC 51449 / 3B1)", "Helicobacter mustelae (strain ATCC 43772 / LMG 18044 / NCTC 12198 / 12198)", ("Helicobacter pylori (strain 35A)", "Helicobacter pylori (strain 51)", "Helicobacter pylori (strain 52)", "Helicobacter pylori (strain 908)", "Helicobacter pylori (strain ATCC 700392 / 26695)", "Helicobacter pylori (strain B38)", "Helicobacter pylori (strain B8)", "Helicobacter pylori (strain Cuz20)", "Helicobacter pylori (strain F16)", "Helicobacter pylori (strain F30)", "Helicobacter pylori (strain F32)", "Helicobacter pylori (strain F57)", "Helicobacter pylori (strain G27)", "Helicobacter pylori (strain Gambia94/24)", "Helicobacter pylori (strain HPAG1)", "Helicobacter pylori (strain India7)", "Helicobacter pylori (strain J99 / ATCC 700824)", "Helicobacter pylori (strain Lithuania75)", "Helicobacter pylori (strain P12)", "Helicobacter pylori (strain PeCan4)", "Helicobacter pylori (strain SJM180)", "Helicobacter pylori (strain Shi470)", "Helicobacter pylori (strain v225d)")"Helicobacter pylori")"Helicobacter", "Sulfuricurvum kujiense (strain ATCC BAA-921 / DSM 16994 / JCM 11577 / YK-1)", ("Sulfurimonas autotrophica (strain ATCC BAA-671 / DSM 16294 / JCM 11897 / OK10)", "Sulfurimonas denitrificans (strain ATCC 33889 / DSM 1251)")"Sulfurimonas", "Wolinella succinogenes (strain ATCC 29543 / DSM 1740 / LMG 7466 / NCTC 11488 / FDC 602W)")"Helicobacteraceae", "Nitratifractor salsuginis (strain DSM 16511 / JCM 12458 / E9I37-1)")"Campylobacterales", "Nautilia profundicola (strain ATCC BAA-1463 / DSM 18972 / AmH)", ("Nitratiruptor sp. (strain SB155-2)", "Sulfurovum sp. (strain NBC37-1)")"unclassified Epsilonproteobacteria")"Epsilonproteobacteria")"delta/epsilon subdivisions")"Proteobacteria", (("Brachyspira hyodysenteriae (strain ATCC 49526 / WA1)", "Brachyspira intermedia (strain ATCC 51140 / PWS/A)", "Brachyspira murdochii (strain ATCC 51284 / DSM 12563 / 56-150)", "Brachyspira pilosicoli (strain ATCC BAA-1826 / 95/1000)")"Brachyspira", ((("Leptospira biflexa serovar Patoc (strain Patoc 1 / ATCC 23582 / Paris)", "Leptospira biflexa serovar Patoc (strain Patoc 1 / Ames)")"Leptospira biflexa serovar Patoc", ("Leptospira borgpetersenii serovar Hardjo-bovis (strain JB197)", "Leptospira borgpetersenii serovar Hardjo-bovis (strain L550)")"Leptospira borgpetersenii serovar Hardjo-bovis", ("Leptospira interrogans serogroup Icterohaemorrhagiae serovar copenhageni (strain Fiocruz L1-130)", ("Leptospira interrogans serogroup Icterohaemorrhagiae serovar Lai (strain 56601)", "Leptospira interrogans serogroup Icterohaemorrhagiae serovar Lai (strain IPAV)")"Leptospira interrogans serovar Lai")"Leptospira interrogans")"Leptospira", "Turneriella parva (strain ATCC BAA-1111 / DSM 21527 / NCTC 11395 / H)")"Leptospiraceae", ((("Borrelia crocidurae (strain Achema)", "Borrelia duttonii (strain Ly)", "Borrelia hermsii (strain HS1 / DAH)", "Borrelia recurrentis (strain A1)", "Borrelia turicatae (strain 91E135)")"Borrelia", ("Borrelia afzelii (strain PKo)", "Borreliella bavariensis (strain ATCC BAA-2496 / DSM 23469 / PBi)", ("Borrelia burgdorferi (strain ATCC 35210 / B31 / CIP 102532 / DSM 4680)", "Borrelia burgdorferi (strain N40)", "Borrelia burgdorferi (strain ZS7)")"Borreliella burgdorferi")"Borreliella")"Borreliaceae", ("Sediminispirochaeta smaragdinae (strain DSM 11293 / JCM 15392 / SEBR 4228)", ("Sphaerochaeta coccoides (strain ATCC BAA-1237 / DSM 17374 / SPN1)", "Sphaerochaeta globosa (strain ATCC BAA-1886 / DSM 22777 / Buddy)", "Sphaerochaeta pleomorpha (strain ATCC BAA-1885 / DSM 22778 / Grapes)")"Sphaerochaeta", ("Spirochaeta africana (strain ATCC 700263 / DSM 8902 / Z-7692)", ("Spirochaeta thermophila (strain ATCC 49972 / DSM 6192 / RI 19.B1)", "Spirochaeta thermophila (strain ATCC 700085 / DSM 6578 / Z-1203)")"Spirochaeta thermophila")"Spirochaeta", ("Treponema azotonutricium (strain ATCC BAA-888 / DSM 13862 / ZAS-9)", "Treponema brennaborense (strain DSM 12168 / CIP 105900 / DD5/3)", "Treponema caldarium (strain ATCC 51460 / DSM 7334 / H1)", "Treponema denticola (strain ATCC 35405 / CIP 103919 / DSM 14222)", (("Treponema pallidum (strain Nichols)", "Treponema pallidum subsp. pallidum (strain Chicago)", "Treponema pallidum subsp. pallidum (strain SS14)")"Treponema pallidum subsp. pallidum", ("Treponema pallidum subsp. pertenue (strain CDC2)", "Treponema pallidum subsp. pertenue (strain Samoa D)")"Treponema pallidum subsp. pertenue")"Treponema pallidum", "Treponema paraluiscuniculi (strain Cuniculi A)", "Treponema primitia (strain ATCC BAA-887 / DSM 12427 / ZAS-2)", "Treponema succinifaciens (strain ATCC 33096 / DSM 2489 / 6091)")"Treponema")"Spirochaetaceae")"Spirochaetales")"Spirochaetia", ("Acetomicrobium mobile (strain ATCC BAA-54 / DSM 13181 / NGA)", "Aminobacterium colombiense (strain DSM 12261 / ALA-1)", "Thermanaerovibrio acidaminovorans (strain ATCC 49978 / DSM 6589 / Su883)", "Thermovirga lienii (strain ATCC BAA-1197 / DSM 17291 / Cas60314)")"Synergistaceae", (("Acholeplasma laidlawii (strain PG-8A)", ("Phytoplasma mali (strain AT)", ("Aster yellows witches\'-broom phytoplasma (strain AYWB)", "Onion yellows phytoplasma (strain OY-M)")"Candidatus Phytoplasma asteris", "Phytoplasma australiense")"Candidatus Phytoplasma")"Acholeplasmataceae", "Mesoplasma florum (strain ATCC 33453 / NBRC 100688 / NCTC 11704 / L1)", ((("Mycoplasma agalactiae (strain 5632)", "Mycoplasma agalactiae (strain PG2)")"Mycoplasma agalactiae", "Mycoplasma arthritidis (strain 158L3-1)", ("Mycoplasma bovis (strain ATCC 25523 / PG45)", "Mycoplasma bovis (strain Hubei-1)")"Mycoplasma bovis", "Mycoplasma capricolum subsp. capricolum (strain California kid / ATCC 27343 / NCTC 10154)", "Mycoplasma conjunctivae (strain ATCC 25834 / HRC/581 / NCTC 10147)", "Mycoplasma crocodyli (strain ATCC 51981 / MP145)", "Mycoplasma cynos (strain C142)", ("Mycoplasma fermentans (strain ATCC 19989 / NBRC 14854 / NCTC 10117 / PG18)", "Mycoplasma fermentans (strain JER)", "Mycoplasma fermentans (strain M64)")"Mycoplasma fermentans", ("Mycoplasma gallisepticum (strain F)", ("Mycoplasma gallisepticum (strain R(high / passage 156))", "Mycoplasma gallisepticum (strain R(low / passage 15 / clone 2))")"Mycoplasma gallisepticum str. R")"Mycoplasma gallisepticum", "Mycoplasma genitalium (strain ATCC 33530 / G-37 / NCTC 10195)", "Mycoplasma haemocanis (strain Illinois)", ("Mycoplasma haemofelis (strain Langford 1)", "Mycoplasma haemofelis (strain Ohio2)")"Mycoplasma haemofelis", "Mycoplasma hominis (strain ATCC 23114 / NBRC 14850 / NCTC 10111 / PG21)", ("Mycoplasma hyopneumoniae (strain 168)", "Mycoplasma hyopneumoniae (strain 232)", "Mycoplasma hyopneumoniae (strain 7448)", "Mycoplasma hyopneumoniae (strain J / ATCC 25934 / NCTC 10110)")"Mycoplasma hyopneumoniae", ("Mycoplasma hyorhinis (strain HUB-1)", "Mycoplasma hyorhinis (strain MCLD)")"Mycoplasma hyorhinis", ("Mycoplasma leachii (strain 99/014/6)", "Mycoplasma leachii (strain DSM 21131 / NCTC 10133 / N29 / PG50)")"Mycoplasma leachii", "Mycoplasma mobile (strain ATCC 43663 / 163K / NCTC 11711)", ("Mycoplasma mycoides subsp. mycoides SC (strain Gladysdale)", "Mycoplasma mycoides subsp. mycoides SC (strain PG1)")"Mycoplasma mycoides subsp. mycoides SC", "Mycoplasma penetrans (strain HF-2)", ("Mycoplasma pneumoniae (strain ATCC 15531 / DSM 22911 / NBRC 14401 / NCTC 10119 / FH)", "Mycoplasma pneumoniae (strain ATCC 29342 / M129)")"Mycoplasma pneumoniae", "Mycoplasma pulmonis (strain UAB CTIP)", "Mycoplasma putrefaciens (strain ATCC 15718 / NCTC 10155 / C30 KS-1 / KS-1)", ("Mycoplasma suis (strain Illinois)", "Mycoplasma suis (strain KI_3806)")"Mycoplasma suis", "Mycoplasma synoviae (strain 53)")"Mycoplasma", (("Ureaplasma parvum serovar 3 (strain ATCC 27815 / 27 / NCTC 11736)", "Ureaplasma parvum serovar 3 (strain ATCC 700970)")"Ureaplasma parvum serovar 3", "Ureaplasma urealyticum serovar 10 (strain ATCC 33699 / Western)")"Ureaplasma")"Mycoplasmataceae")"Mollicutes", "Thermobaculum terrenum (strain ATCC BAA-798 / YNP1)", ("Thermodesulfatator indicus (strain DSM 15286 / JCM 11887 / CIR29812)", "Thermodesulfobacterium geofontis (strain OPF15)")"Thermodesulfobacteriaceae", ("Kosmotoga olearia (strain TBF 19.5.1)", ("Marinitoga piezophila (strain DSM 14283 / JCM 11233 / KA3)", "Petrotoga mobilis (strain DSM 10674 / SJ95)")"Petrotogaceae", ((("Fervidobacterium nodosum (strain ATCC 35602 / DSM 5306 / Rt17-B1)", "Fervidobacterium pennivorans (strain DSM 9078 / Ven5)")"Fervidobacterium", ("Thermosipho africanus (strain TCF52B)", "Thermosipho melanesiensis (strain DSM 12029 / CIP 104789 / BI429)")"Thermosipho")"Fervidobacteriaceae", ("Pseudothermotoga lettingae (strain ATCC BAA-301 / DSM 14385 / NBRC 107922 / TMO)", ("Thermotoga maritima (strain ATCC 43589 / MSB8 / DSM 3109 / JCM 10099)", "Thermotoga naphthophila (strain ATCC BAA-489 / DSM 13996 / JCM 10882 / RKU-10)", "Thermotoga neapolitana (strain ATCC 49049 / DSM 4359 / NS-E)", "Thermotoga petrophila (strain RKU-1 / ATCC BAA-488 / DSM 13995)", "Thermotoga sp. (strain RQ2)")"Thermotoga")"Thermotogaceae")"Thermotogales")"Thermotogae", ("Methylacidiphilum infernorum (isolate V4)", ("Opitutus terrae (strain DSM 11246 / JCM 15787 / PB90-1)", "Coraliomargarita akajimensis (strain DSM 45221 / IAM 15411 / JCM 23193 / KCTC 12865 / 04OKA010-24)")"Opitutae", "Akkermansia muciniphila (strain ATCC BAA-835 / Muc)")"Verrucomicrobia")"Bacteria", ((((("Plasmodium falciparum (isolate 3D7)", "Plasmodium vivax (strain Salvador I)", "Plasmodium yoelii yoelii")"Plasmodium", (("Babesia bigemina", "Babesia bovis", "Babesia microti (strain RI)")"Babesia", "Theileria annulata")"Piroplasmida")"Aconoidasida", ((("Cryptosporidium muris (strain RN66)", (CRYPV, "Cryptosporidium parvum (strain Iowa II)")"Cryptosporidium parvum")"Cryptosporidium", ("Eimeria acervulina", "Eimeria maxima", "Eimeria tenella")"Eimeria", ("Hammondia hammondi", "Toxoplasma gondii")"Sarcocystidae")"Eimeriorina", "Gregarina niphandrodes")"Conoidasida")"Apicomplexa", "Vitrella brassicaformis (strain CCMP3155)", (("Ichthyophthirius multifiliis", "Tetrahymena thermophila (strain SB210)")"Hymenostomatida", "Paramecium tetraurelia")"Oligohymenophorea", "Perkinsus marinus (strain ATCC 50983 / TXsc)")"Alveolata", (("Entamoeba dispar (strain ATCC PRA-260 / SAW760)", "Entamoeba histolytica", "Entamoeba nuttalli (strain P19)")"Entamoeba", (("Dictyostelium discoideum", "Dictyostelium purpureum")"Dictyostelium", "Polysphondylium pallidum (strain ATCC 26659 / Pp 5 / PN500)")"Dictyosteliida")"Amoebozoa", "Guillardia theta", (((("Leishmania donovani (strain BPK282A1)", "Leishmania infantum")"Leishmania donovani species complex", "Leishmania major", "Leishmania mexicana (strain MHOM/GT/2001/U1103)", "Leishmania braziliensis")"Leishmania", "Leptomonas seymouri")"Leishmaniinae", "Trypanosoma brucei brucei (strain 927/4 GUTat10.1)")"Trypanosomatidae", ("Giardia intestinalis (strain ATCC 50581 / GS clone H7)", "Giardia intestinalis (strain ATCC 50803 / WB clone C6)")"Giardia intestinalis", "Emiliania huxleyi", "Naegleria gruberi", (("Monosiga brevicollis", "Salpingoeca rosetta (strain ATCC 50818 / BSB-021)")"Salpingoecidae", (((BATDE, "Batrachochytrium dendrobatidis (strain JAM81 / FGSC 10211)")"Batrachochytrium dendrobatidis", "Spizellomyces punctatus")"Chytridiomycetes", (("Schizosaccharomyces pombe (strain 972 / ATCC 24843)", (("Tuber melanosporum (strain Mel28)", (((("Aspergillus aculeatus", "Aspergillus clavatus (strain ATCC 1007 / CBS 513.65 / DSM 816 / NCTC 3887 / NRRL 1)", "Neosartorya fischeri (strain ATCC 1020 / DSM 3700 / CBS 544.65 / FGSC A1164 / JCM 1740 / NRRL 181 / WB 181)", "Aspergillus flavus (strain ATCC 200026 / FGSC A1120 / NRRL 3357 / JCM 12722 / SRRC 167)", "Aspergillus glaucus", "Aspergillus oryzae (strain ATCC 42149 / RIB 40)", "Aspergillus terreus (strain NIH 2624 / FGSC A1156)", (EMEND, "Emericella nidulans (strain FGSC A4 / ATCC 38163 / CBS 112.46 / NRRL 194 / M139)")"Emericella nidulans", "Neosartorya fumigata (strain ATCC MYA-4609 / Af293 / CBS 101355 / FGSC A1100)")"Aspergillus", ("Penicillium chrysogenum", "Penicillium rubens (strain ATCC 28089 / DSM 1075 / NRRL 1951 / Wisconsin 54-1255)")"Penicillium chrysogenum species complex")"Aspergillaceae", "Talaromyces stipitatus (strain ATCC 10500 / CBS 375.48 / QM 6759 / NRRL 1006)")"Eurotiales", ((("Passalora fulva", "Zymoseptoria tritici")"Mycosphaerellaceae", "Aureobasidium pullulans")"Dothideomycetidae", ("Leptosphaeria maculans (strain JN3 / isolate v23.1.3 / race Av1-4-5-6-7-8)", (PHAND, "Phaeosphaeria nodorum (strain SN15 / ATCC MYA-4574 / FGSC 10173)")"Phaeosphaeria nodorum", "Cochliobolus lunatus")"Pleosporineae")"Dothideomycetes", (("Blumeria graminis", ("Botryotinia fuckeliana (strain B05.10)", "Sclerotinia sclerotiorum (strain ATCC 18683 / 1980 / Ss-1)")"Sclerotiniaceae")"Leotiomycetes", (((("Colletotrichum graminicola", "Colletotrichum sublineola")"Colletotrichum", "Verticillium dahliae")"Glomerellales", (("Hypocrea atroviridis (strain ATCC 20476 / IMI 206040)", "Hypocrea jecorina", "Hypocrea virens (strain Gv29-8 / FGSC 10586)")"Trichoderma", ("Fusarium oxysporum f. sp. lycopersici (strain 4287 / CBS 123668 / FGSC 9935 / NRRL 34936)", "Gibberella zeae", "Nectria haematococca")"Fusarium")"Hypocreales")"Hypocreomycetidae", ("Cryphonectria parasitica", "Magnaporthe grisea", ("Thielavia heterothallica", ("Neurospora crassa (strain ATCC 24698 / 74-OR23-1A / CBS 708.71 / DSM 1257 / FGSC 987)", "Neurospora tetrasperma (strain FGSC 2509 / P0656)")"Neurospora")"Sordariales")"Sordariomycetidae")"Sordariomycetes")"sordariomyceta")"leotiomyceta")"Pezizomycotina", (((("Candida albicans (strain SC5314 / ATCC MYA-2876)", "Candida albicans (strain WO-1)")"Candida albicans", "Lodderomyces elongisporus (strain ATCC 11503 / CBS 2605 / JCM 1781 / NBRC 1676 / NRRL YB-4239)")"Candida/Lodderomyces clade", "Debaryomyces hansenii (strain ATCC 36239 / CBS 767 / JCM 1990 / NBRC 0083 / IGC 2968)", "Meyerozyma guilliermondii (strain ATCC 6260 / CBS 566 / DSM 6381 / JCM 1539 / NBRC 10279 / NRRL Y-324)", "Scheffersomyces stipitis (strain ATCC 58785 / CBS 6054 / NBRC 10063 / NRRL Y-11545)", "Spathaspora passalidarum (strain NRRL Y-27907 / 11-Y1)", "Candida tenuis")"Debaryomycetaceae", "Yarrowia lipolytica (strain CLIB 122 / E 150)", "Komagataella phaffii (strain GS115 / ATCC 20864)", "Dekkera bruxellensis", ("Ashbya gossypii (strain ATCC 10895 / CBS 109.51 / FGSC 9923 / NRRL Y-1056)", "Kluyveromyces lactis (strain ATCC 8585 / CBS 2359 / DSM 70799 / NBRC 1267 / NRRL Y-1140 / WM37)", "Candida glabrata (strain ATCC 2001 / CBS 138 / JCM 3761 / NBRC 0622 / NRRL Y-65)", "Saccharomyces cerevisiae (strain ATCC 204508 / S288c)", "Zygosaccharomyces rouxii")"Saccharomycetaceae")"Saccharomycetales")"saccharomyceta")"Ascomycota", (((("Auricularia subglabra (strain TFB-10046 / SS5)", "Punctularia strigosozonata (strain HHB-11173)", "Gloeophyllum trabeum", "Fomitiporia mediterranea (strain MF3/22)", (("Postia placenta (strain ATCC 44394 / Madison 698-R)", "Trametes versicolor (strain FP-101664)", "Wolfiporia cocos (strain MD-104)")"Coriolaceae", "Fomitopsis pinicola (strain FP-58527)", ("Phanerochaete chrysosporium", "Phlebiopsis gigantea")"Phanerochaetaceae", "Dichomitus squalens (strain LYAD-421)")"Polyporales", ("Heterobasidion annosum", "Stereum hirsutum (strain FP-91666)")"Russulales", "Serendipita indica (strain DSM 11827)")"Agaricomycetes incertae sedis", (("Agaricus bisporus", "Coprinopsis cinerea", "Schizophyllum commune", "Laccaria bicolor")"Agaricales", "Coniophora puteana (strain RWD-64-598)")"Agaricomycetidae")"Agaricomycetes", (("Cryptococcus gattii", "Cryptococcus neoformans var. neoformans serotype D (strain JEC21 / ATCC MYA-565)")"Cryptococcus", "Tremella mesenterica")"Tremellales", "Wallemia sebi")"Agaricomycotina", ("Mixia osmundae (strain CBS 9802 / IAM 14324 / JCM 22182 / KY 12970)", (PUCGR, "Puccinia graminis f. sp. tritici (strain CRL 75-36-700-3 / race SCCL)")"Puccinia graminis")"Pucciniomycotina", ("Ustilago hordei", "Ustilago maydis (strain 521 / FGSC 9021)")"Ustilago")"Basidiomycota")"Dikarya", "Encephalitozoon cuniculi (strain GB-M1)", (("Mucor circinelloides", "Rhizopus oryzae")"Mucorineae", "Phycomyces blakesleeanus")"Mucorales")"Fungi", ((((("Branchiostoma floridae", ("Petromyzon marinus", (("Lepisosteus oculatus", (((("Gasterosteus aculeatus", ("Takifugu rubripes", "Tetraodon nigroviridis")"Tetraodontidae")"Eupercaria", (("Oryzias latipes", ("Poecilia formosa", "Xiphophorus maculatus")"Poeciliinae")"Atherinomorphae", "Oreochromis niloticus")"Ovalentaria")"Percomorphaceae", "Gadus morhua")"Acanthomorphata", ("Astyanax mexicanus", "Danio rerio")"Otophysi")"Clupeocephala")"Neopterygii", ("Latimeria chalumnae", ((("Ornithorhynchus anatinus", ((("Procavia capensis", "Loxodonta africana", "Echinops telfairi")"Afrotheria", (((("Oryctolagus cuniculus", "Ochotona princeps")"Lagomorpha", ("Dipodomys ordii", "Cavia porcellus", ("Mus musculus", "Rattus norvegicus")"Murinae", "Ictidomys tridecemlineatus")"Rodentia")"Glires", ((((("Chlorocebus sabaeus", "Macaca mulatta", "Papio anubis")"Cercopithecinae", ((("Gorilla gorilla gorilla", "Homo sapiens", "Pan troglodytes")"Homininae", "Pongo abelii")"Hominidae", "Nomascus leucogenys")"Hominoidea")"Catarrhini", "Callithrix jacchus")"Simiiformes", "Tarsius syrichta")"Haplorrhini", ("Microcebus murinus", "Otolemur garnettii")"Strepsirrhini")"Primates", "Tupaia belangeri")"Euarchontoglires", ((("Canis lupus familiaris", "Mustela putorius furo", "Ailuropoda melanoleuca")"Caniformia", "Felis catus")"Carnivora", ("Tursiops truncatus", ("Bos taurus", "Ovis aries")"Bovidae", "Sus scrofa", "Vicugna pacos")"Cetartiodactyla", ("Pteropus vampyrus", "Myotis lucifugus")"Chiroptera", ("Erinaceus europaeus", "Sorex araneus")"Insectivora", "Equus caballus")"Laurasiatheria")"Boreoeutheria", ("Dasypus novemcinctus", "Choloepus hoffmanni")"Xenarthra")"Eutheria", ("Sarcophilus harrisii", "Monodelphis domestica", "Macropus eugenii")"Metatheria")"Theria")"Mammalia", (((("Anas platyrhynchos", ("Meleagris gallopavo", "Gallus gallus")"Phasianidae")"Galloanserae", ("Ficedula albicollis", "Taeniopygia guttata")"Passeriformes")"Neognathae", "Pelodiscus sinensis")"Archelosauria", "Anolis carolinensis")"Sauria")"Amniota", "Xenopus tropicalis")"Tetrapoda")"Sarcopterygii")"Euteleostomi")"Vertebrata", ("Ciona intestinalis", "Ciona savignyi")"Ciona")"Chordata", "Strongylocentrotus purpuratus")"Deuterostomia", "Schistosoma mansoni", (((("Pristionchus pacificus", ("Strongyloides ratti", ("Caenorhabditis brenneri", "Caenorhabditis briggsae", "Caenorhabditis elegans", "Caenorhabditis japonica", "Caenorhabditis remanei")"Caenorhabditis")"Rhabditida", ("Brugia malayi", "Loa loa", "Onchocerca volvulus")"Onchocercidae")"Chromadorea", "Trichinella spiralis")"Nematoda", (((("Sarcoptes scabiei", "Tetranychus urticae")"Acariformes", "Ixodes scapularis")"Acari", ("Strigamia maritima", (("Daphnia pulex", "Lepeophtheirus salmonis")"Crustacea", ((("Bombyx mori", ("Danaus plexippus", "Heliconius melpomene", "Melitaea cinxia")"Nymphalidae")"Obtectomera", ("Dendroctonus ponderosae", "Tribolium castaneum")"Cucujiformia", (("Megaselia scalaris", (("Drosophila virilis", "Drosophila grimshawi", ("Drosophila biarmipes", "Drosophila elegans", "Drosophila erecta", "Drosophila eugracilis", "Drosophila ficusphila", "Drosophila kikkawai", "Drosophila melanogaster", "Drosophila persimilis", "Drosophila pseudoobscura pseudoobscura", "Drosophila rhopaloa", "Drosophila sechellia", "Drosophila simulans", "Drosophila takahashii", "Drosophila willistoni", "Drosophila yakuba", "Drosophila ananassae", "Drosophila bipectinata")"Sophophora", "Drosophila mojavensis")"Drosophila", "Lucilia cuprina")"Schizophora")"Cyclorrhapha", (("Anopheles gambiae", "Anopheles darlingi")"Anopheles", ("Aedes aegypti", "Culex quinquefasciatus")"Culicinae")"Culicidae")"Diptera", ((("Apis mellifera", "Bombus impatiens")"Apidae", ("Linepithema humile", "Cerapachys biroi", "Camponotus floridanus", ("Atta cephalotes", "Solenopsis invicta")"Myrmicinae", "Harpegnathos saltator")"Formicidae")"Aculeata", "Nasonia vitripennis")"Apocrita")"Holometabola", (("Rhodnius prolixus", "Acyrthosiphon pisum")"Hemiptera", "Pediculus humanus subsp. corporis")"Paraneoptera", "Zootermopsis nevadensis")"Neoptera")"Pancrustacea")"Mandibulata")"Arthropoda", "Hypsibius dujardini")"Panarthropoda")"Ecdysozoa", (("Helobdella robusta", ("Capitella sp. 1", "Capitella teleta")"Capitella")"Annelida", "Lingula unguis", ("Crassostrea gigas", "Octopus bimaculoides", "Lottia gigantea")"Mollusca")"Lophotrochozoa")"Protostomia")"Bilateria", ("Nematostella vectensis", "Thelohanellus kitauei")"Cnidaria", "Mnemiopsis leidyi")"Eumetazoa", "Trichoplax adhaerens", "Amphimedon queenslandica")"Metazoa", ("Capsaspora owczarzaki (strain ATCC 30864)", "Creolimax fragrantissima")"Ichthyosporea")"Opisthokonta", ("Bigelowiella natans (strain CCMP2755)", "Reticulomyxa filosa")"Rhizaria", (("Cyanidioschyzon merolae", "Galdieria sulphuraria")"Cyanidiaceae", "Chondrus crispus")"Rhodophyta", (("Phaeodactylum tricornutum (strain CCAP 1055/1)", "Thalassiosira pseudonana")"Bacillariophyta", "Blastocystis hominis", "Nannochloropsis gaditana (strain CCMP526)", (("Hyaloperonospora arabidopsidis (strain Emoy2)", ("Phytophthora infestans (strain T30-4)", "Phytophthora nicotianae", "Phytophthora parasitica")"Phytophthora")"Peronosporales", "Saprolegnia parasitica (strain CBS 223.65)")"Oomycetes", "Ectocarpus siliculosus", "Aureococcus anophagefferens")"Stramenopiles", ((("Chlamydomonas reinhardtii", "Volvox carteri")"Chlamydomonadales", "Chlorella variabilis", (("Ostreococcus lucimarinus (strain CCE9901)", "Ostreococcus tauri")"Ostreococcus", ("Micromonas commoda (strain RCC299 / NOUM17 / CCMP2709)", "Micromonas pusilla (strain CCMP1545)")"Micromonas")"Mamiellales")"Chlorophyta", ("Klebsormidium flaccidum", ("Physcomitrella patens subsp. patens", ((((((("Oryza brachyantha", "Oryza glaberrima", "Oryza longistaminata", "Oryza nivara", "Oryza punctata", "Oryza rufipogon", ("Oryza sativa subsp. indica", "Oryza sativa subsp. japonica")"Oryza sativa")"Oryza", ("Brachypodium distachyon", ("Hordeum vulgare var. distichon", ("Aegilops tauschii", ("Triticum aestivum", "Triticum urartu")"Triticum")"Triticinae")"Triticeae")"Pooideae")"BOP clade", ("Eragrostis tef", (("Sorghum bicolor", "Zea mays")"Andropogoneae", "Setaria italica")"Panicoideae")"PACMAD clade")"Poaceae", (MUSAC, "Musa acuminata subsp. malaccensis")"Musa acuminata")"commelinids", (("Solanum lycopersicum", "Solanum tuberosum")"Solanum", ((("Lotus japonicus", "Glycine max", "Medicago truncatula")"Papilionoideae", ("Manihot esculenta", "Populus trichocarpa")"Malpighiales", "Prunus persica")"fabids", (("Arabis alpina", ("Brassica rapa subsp. pekinensis", "Brassica napus", "Brassica oleracea")"Brassica", ("Arabidopsis lyrata", "Arabidopsis thaliana")"Arabidopsis")"Brassicaceae", ("Theobroma cacao", "Gossypium hirsutum")"Malvaceae")"malvids", "Vitis vinifera")"rosids")"Pentapetalae")"Mesangiospermae", "Amborella trichopoda")"Magnoliophyta", "Selaginella moellendorffii")"Tracheophyta")"Embryophyta")"Streptophyta")"Viridiplantae")"Eukaryota")"LUCA";',
+  "orthoxml": '<?xml version=\'1.0\' encoding=\'UTF-8\'?>\n' +
+  '<orthoXML xmlns="http://orthoXML.org/2011/" origin="OMA" originVersion="Nov 2017" version="0.3">\n' +
+  '  <species name="Atta cephalotes" NCBITaxId="12957">\n' +
+  '    <database name="Atta cephalotes from ENSEMBL Metazoa v12" version="Ensembl Metazoa 12; Acep1; 15-DEC-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="9261860" protId="ATTCE16616"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dasypus novemcinctus" NCBITaxId="9361">\n' +
+  '    <database name="Dasypus novemcinctus from ENSEMBL v78" version="Ensembl 78; Dasnov3.0; 21-NOV-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8081407" protId="DASNO01043"/>\n' +
+  '        <gene id="8086413" protId="DASNO06049"/>\n' +
+  '        <gene id="8094152" protId="DASNO13788"/>\n' +
+  '        <gene id="8094822" protId="DASNO14458"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hypocrea virens (strain Gv29-8 / FGSC 10586)" NCBITaxId="413071">\n' +
+  '    <database name="Hypocrea virens from JGI" version="JGI; TriviGv29_8_2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6451735" protId="HYPVG07097"/>\n' +
+  '        <gene id="6454713" protId="HYPVG10075"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Agaricus bisporus" NCBITaxId="192523">\n' +
+  '    <database name="Agaricus bisporus complete genome from JGI" version="v2.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6824764" protId="AGABI00940"/>\n' +
+  '        <gene id="6831839" protId="AGABI08015"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Emericella nidulans" NCBITaxId="162425">\n' +
+  '    <database name="Emericella nidulans from JGI" version="JGI; Aspnid1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6200921" protId="EMEND10444"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Callithrix jacchus" NCBITaxId="9483">\n' +
+  '    <database name="Callithrix jacchus from ENSEMBL v70" version="Ensembl 70; C_jacchus3.2.1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7757401" protId="CALJA22257"/>\n' +
+  '        <gene id="7738364" protId="CALJA03220"/>\n' +
+  '        <gene id="7757748" protId="CALJA22604"/>\n' +
+  '        <gene id="7750671" protId="CALJA15527"/>\n' +
+  '        <gene id="7736882" protId="CALJA01738"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Solenopsis invicta" NCBITaxId="13686">\n' +
+  '    <database name="Solenopsis invicta from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; GCA_000188075.1; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="9275975" protId="SOLIN12965"/>\n' +
+  '        <gene id="9275972" protId="SOLIN12962"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Megaselia scalaris" NCBITaxId="36166">\n' +
+  '    <database name="Megaselia scalaris from ENSEMBL metazoa v23" version="Ensembl Metazoa 23; Msca1; 21-AUG-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8793548" protId="MEGSC11145"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila ficusphila" NCBITaxId="30025">\n' +
+  '    <database name="Drosophila ficusphila from modENCODE" version="modENCODE; 0.5.3">\n' +
+  '      <genes>\n' +
+  '        <gene id="8887140" protId="DROFC04323"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila willistoni" NCBITaxId="7260">\n' +
+  '    <database name="Drosophila willistoni from ENSEMBL Metazoa v3" version="Ensembl Metazoa 3; dwil_r1.3_FB2008_07; 20-AUG-2009">\n' +
+  '      <genes>\n' +
+  '        <gene id="9038225" protId="DROWI13430"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza brachyantha" NCBITaxId="4533">\n' +
+  '    <database name="Oryza brachyantha from ENSEMBL plants v21" version="Ensembl Plants 21; Oryza_brachyantha.v1.4b; 5-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10082744" protId="ORYBR01467"/>\n' +
+  '        <gene id="10102509" protId="ORYBR21232"/>\n' +
+  '        <gene id="10088558" protId="ORYBR07281"/>\n' +
+  '        <gene id="10111024" protId="ORYBR29747"/>\n' +
+  '        <gene id="10084100" protId="ORYBR02823"/>\n' +
+  '        <gene id="10084712" protId="ORYBR03435"/>\n' +
+  '        <gene id="10102892" protId="ORYBR21615"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Monodelphis domestica" NCBITaxId="13616">\n' +
+  '    <database name="Monodelphis domestica from ENSEMBL v80" version="Ensembl 80; BROADO5; 15-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="8143392" protId="MONDO07829"/>\n' +
+  '        <gene id="8142110" protId="MONDO06547"/>\n' +
+  '        <gene id="8138413" protId="MONDO02850"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gallus gallus" NCBITaxId="9031">\n' +
+  '    <database name="Gallus gallus from ENSEMBL v75" version="Ensembl 75; Galgal4; 7-FEB-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8199358" protId="CHICK01309"/>\n' +
+  '        <gene id="8200421" protId="CHICK02372"/>\n' +
+  '        <gene id="8207969" protId="CHICK09920"/>\n' +
+  '        <gene id="8199922" protId="CHICK01873"/>\n' +
+  '        <gene id="8207223" protId="CHICK09174"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Strigamia maritima" NCBITaxId="126957">\n' +
+  '    <database name="Strigamia maritima from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; Smar1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8646132" protId="STRMM09379"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Creolimax fragrantissima" NCBITaxId="470921">\n' +
+  '    <database name="Creolimax fragrantissima from Multicellgenome" version="Multicellgenome; GCA_002024145.1; 15-OCT-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9723567" protId="CREFR08136"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila simulans" NCBITaxId="7240">\n' +
+  '    <database name="Drosophila simulans from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000259055.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="9000203" protId="DROSI04168"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Musa acuminata" NCBITaxId="4641">\n' +
+  '    <database name="Musa acuminata from ENSEMBL plants v18" version="Ensembl Plants 18; MA1; 8-APR-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10802385" protId="MUSAC28010"/>\n' +
+  '        <gene id="10798369" protId="MUSAC23994"/>\n' +
+  '        <gene id="10796236" protId="MUSAC21861"/>\n' +
+  '        <gene id="10776504" protId="MUSAC02129"/>\n' +
+  '        <gene id="10787865" protId="MUSAC13490"/>\n' +
+  '        <gene id="10794891" protId="MUSAC20516"/>\n' +
+  '        <gene id="10795741" protId="MUSAC21366"/>\n' +
+  '        <gene id="10798204" protId="MUSAC23829"/>\n' +
+  '        <gene id="10787637" protId="MUSAC13262"/>\n' +
+  '        <gene id="10801934" protId="MUSAC27559"/>\n' +
+  '        <gene id="10803937" protId="MUSAC29562"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pediculus humanus subsp. corporis" NCBITaxId="121224">\n' +
+  '    <database name="Pediculus humanus corporis full genome from ENSEMBL Metazoa v5" version="Ensembl Metazoa v5; PhumU1; 15-MAY-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="9370390" protId="PEDHC09994"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus glaucus" NCBITaxId="41413">\n' +
+  '    <database name="Eurotium herbariorum from JGI" version="JGI; Eurhe1; 12-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6160631" protId="ASPGL02622"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila elegans" NCBITaxId="30023">\n' +
+  '    <database name="Drosophila elegans from modENCODE" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="8850883" protId="DROEL12287"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Coniophora puteana (strain RWD-64-598)" NCBITaxId="741705">\n' +
+  '    <database name="Coniophora puteana from JGI" version="JGI; Conpu1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6887191" protId="CONPW00916"/>\n' +
+  '        <gene id="6893835" protId="CONPW07560"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Glycine max" NCBITaxId="3847">\n' +
+  '    <database name="Glycine max from ENSEMBL plants v19" version="Ensembl Plants 19; V1.0; 24-JUN-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10972216" protId="SOYBN10020"/>\n' +
+  '        <gene id="10979505" protId="SOYBN17309"/>\n' +
+  '        <gene id="10986156" protId="SOYBN23960"/>\n' +
+  '        <gene id="10970379" protId="SOYBN08183"/>\n' +
+  '        <gene id="10974529" protId="SOYBN12333"/>\n' +
+  '        <gene id="10994228" protId="SOYBN32032"/>\n' +
+  '        <gene id="10992049" protId="SOYBN29853"/>\n' +
+  '        <gene id="11006924" protId="SOYBN44728"/>\n' +
+  '        <gene id="10986283" protId="SOYBN24087"/>\n' +
+  '        <gene id="10964805" protId="SOYBN02609"/>\n' +
+  '        <gene id="10974140" protId="SOYBN11944"/>\n' +
+  '        <gene id="11013623" protId="SOYBN51427"/>\n' +
+  '        <gene id="11015614" protId="SOYBN53418"/>\n' +
+  '        <gene id="11001139" protId="SOYBN38943"/>\n' +
+  '        <gene id="10983188" protId="SOYBN20992"/>\n' +
+  '        <gene id="10999244" protId="SOYBN37048"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Klebsormidium flaccidum" NCBITaxId="3175">\n' +
+  '    <database name="Klebsormidium flaccidum" version="DF238761.1  GI:645719678">\n' +
+  '      <genes>\n' +
+  '        <gene id="10042118" protId="KLEFL09869"/>\n' +
+  '        <gene id="10034829" protId="KLEFL02580"/>\n' +
+  '        <gene id="10038263" protId="KLEFL06014"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila virilis" NCBITaxId="7244">\n' +
+  '    <database name="Drosophila virilis full genome from ENSEMBL Metazoa v5" version="Ensembl Metazoa v5; dvir_r1.2_FB2008_07; 15-MAY-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="8797781" protId="DROVI03950"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Acaryochloris marina (strain MBIC 11017)" NCBITaxId="329726">\n' +
+  '    <database name="Acaryochloris marina (strain MBIC 11017) chromosome, complete sequence." version="18-MAR-2008 (Rel. 88, Last updated, Version 2)">\n' +
+  '      <genes>\n' +
+  '        <gene id="1581134" protId="ACAM102973"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Micromonas commoda (strain RCC299 / NOUM17 / CCMP2709)" NCBITaxId="296587">\n' +
+  '    <database name="Micromonas commoda from ENA" version="ENA; GCA_000090985.2">\n' +
+  '      <genes>\n' +
+  '        <gene id="10013493" protId="MICCC01622"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Vitrella brassicaformis (strain CCMP3155)" NCBITaxId="1169540">\n' +
+  '    <database name="Vitrella brassicaformis CCMP3155 from ENSEMBL protists v32" version="Ensembl Protists 32; Vbrassicaformis; 3-AUG-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="5747339" protId="VITBC07042"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gossypium hirsutum" NCBITaxId="3635">\n' +
+  '    <database name="Gossypium hirsutum from " version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="11527973" protId="GOSHI56637"/>\n' +
+  '        <gene id="11479699" protId="GOSHI08363"/>\n' +
+  '        <gene id="11536586" protId="GOSHI65250"/>\n' +
+  '        <gene id="11504470" protId="GOSHI33134"/>\n' +
+  '        <gene id="11475409" protId="GOSHI04073"/>\n' +
+  '        <gene id="11535623" protId="GOSHI64287"/>\n' +
+  '        <gene id="11513691" protId="GOSHI42355"/>\n' +
+  '        <gene id="11500188" protId="GOSHI28852"/>\n' +
+  '        <gene id="11534398" protId="GOSHI63062"/>\n' +
+  '        <gene id="11486386" protId="GOSHI15050"/>\n' +
+  '        <gene id="11509752" protId="GOSHI38416"/>\n' +
+  '        <gene id="11528095" protId="GOSHI56759"/>\n' +
+  '        <gene id="11496497" protId="GOSHI25161"/>\n' +
+  '        <gene id="11514149" protId="GOSHI42813"/>\n' +
+  '        <gene id="11472257" protId="GOSHI00921"/>\n' +
+  '        <gene id="11534380" protId="GOSHI63044"/>\n' +
+  '        <gene id="11494260" protId="GOSHI22924"/>\n' +
+  '        <gene id="11483742" protId="GOSHI12406"/>\n' +
+  '        <gene id="11484185" protId="GOSHI12849"/>\n' +
+  '        <gene id="11504836" protId="GOSHI33500"/>\n' +
+  '        <gene id="11525612" protId="GOSHI54276"/>\n' +
+  '        <gene id="11516783" protId="GOSHI45447"/>\n' +
+  '        <gene id="11509154" protId="GOSHI37818"/>\n' +
+  '        <gene id="11480228" protId="GOSHI08892"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phlebiopsis gigantea" NCBITaxId="82310">\n' +
+  '    <database name="Phlebiopsis gigantea from JGI" version="JGI; Phlgi1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6763236" protId="PHLGI01434"/>\n' +
+  '        <gene id="6771451" protId="PHLGI09649"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Erinaceus europaeus" NCBITaxId="9365">\n' +
+  '    <database name="Erinaceus europaeus from ENSEMBL v70" version="Ensembl 70; HEDGEHOG; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8044139" protId="ERIEU11764"/>\n' +
+  '        <gene id="8041498" protId="ERIEU09123"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila yakuba" NCBITaxId="7245">\n' +
+  '    <database name="Drosophila yakuba from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; dyak_r1.3_FB2008_07; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="9044893" protId="DROYA04853"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Latimeria chalumnae" NCBITaxId="7897">\n' +
+  '    <database name="Latimeria chalumnae from ENSEMBL v70" version="Ensembl 70; LatCha1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7344433" protId="LATCH12816"/>\n' +
+  '        <gene id="7345070" protId="LATCH13453"/>\n' +
+  '        <gene id="7336186" protId="LATCH04569"/>\n' +
+  '        <gene id="7334963" protId="LATCH03346"/>\n' +
+  '        <gene id="7347993" protId="LATCH16376"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Brugia malayi" NCBITaxId="6279">\n' +
+  '    <database name="Brugia malayi from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; B_malayi-3; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8532643" protId="BRUMA02536"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Nectria haematococca" NCBITaxId="140110">\n' +
+  '    <database name="Nectria haematococca from JGI" version="JGI; Necha2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6494500" protId="NECHA07545"/>\n' +
+  '        <gene id="6491188" protId="NECHA04233"/>\n' +
+  '        <gene id="6487886" protId="NECHA00931"/>\n' +
+  '        <gene id="6492092" protId="NECHA05137"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila pseudoobscura pseudoobscura" NCBITaxId="46245">\n' +
+  '    <database name="Drosophila pseudoobscura from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; HGSC2; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8959766" protId="DROPS10133"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Bos taurus" NCBITaxId="9913">\n' +
+  '    <database name="Bos taurus from ENSEMBL v70" version="Ensembl 70; UMD3.1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7940366" protId="BOVIN20109"/>\n' +
+  '        <gene id="7939626" protId="BOVIN19369"/>\n' +
+  '        <gene id="7921170" protId="BOVIN00913"/>\n' +
+  '        <gene id="7940006" protId="BOVIN19749"/>\n' +
+  '        <gene id="7933260" protId="BOVIN13003"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phanerochaete chrysosporium" NCBITaxId="5306">\n' +
+  '    <database name="Phanerochaete chrysosporium from JGI" version="JGI; Phchr1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6760906" protId="PHACH09038"/>\n' +
+  '        <gene id="6754473" protId="PHACH02605"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phytophthora infestans (strain T30-4)" NCBITaxId="403677">\n' +
+  '    <database name="Phytophthora infestans from Broad Institute" version="BroadInstitute; v1; 15-06-2009">\n' +
+  '      <genes>\n' +
+  '        <gene id="9855002" protId="PHYIT02925"/>\n' +
+  '        <gene id="9855743" protId="PHYIT03666"/>\n' +
+  '        <gene id="9860970" protId="PHYIT08893"/>\n' +
+  '        <gene id="9864612" protId="PHYIT12535"/>\n' +
+  '        <gene id="9855000" protId="PHYIT02923"/>\n' +
+  '        <gene id="9853163" protId="PHYIT01086"/>\n' +
+  '        <gene id="9855735" protId="PHYIT03658"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Triticum aestivum" NCBITaxId="4565">\n' +
+  '    <database name="Triticum aestivum from Ensembl Plants 33" version="Ensembl Plants 33; TGACv1">\n' +
+  '      <genes>\n' +
+  '        <gene id="10499457" protId="WHEAT52556"/>\n' +
+  '        <gene id="10508503" protId="WHEAT61602"/>\n' +
+  '        <gene id="10524683" protId="WHEAT77782"/>\n' +
+  '        <gene id="10493148" protId="WHEAT46247"/>\n' +
+  '        <gene id="10505884" protId="WHEAT58983"/>\n' +
+  '        <gene id="10566973" protId="WHEAT120072"/>\n' +
+  '        <gene id="10499555" protId="WHEAT52654"/>\n' +
+  '        <gene id="10574484" protId="WHEAT127583"/>\n' +
+  '        <gene id="10465177" protId="WHEAT18276"/>\n' +
+  '        <gene id="10527309" protId="WHEAT80408"/>\n' +
+  '        <gene id="10544696" protId="WHEAT97795"/>\n' +
+  '        <gene id="10564358" protId="WHEAT117457"/>\n' +
+  '        <gene id="10500545" protId="WHEAT53644"/>\n' +
+  '        <gene id="10547038" protId="WHEAT100137"/>\n' +
+  '        <gene id="10463383" protId="WHEAT16482"/>\n' +
+  '        <gene id="10524386" protId="WHEAT77485"/>\n' +
+  '        <gene id="10476973" protId="WHEAT30072"/>\n' +
+  '        <gene id="10473597" protId="WHEAT26696"/>\n' +
+  '        <gene id="10552003" protId="WHEAT105102"/>\n' +
+  '        <gene id="10488551" protId="WHEAT41650"/>\n' +
+  '        <gene id="10564292" protId="WHEAT117391"/>\n' +
+  '        <gene id="10526126" protId="WHEAT79225"/>\n' +
+  '        <gene id="10497647" protId="WHEAT50746"/>\n' +
+  '        <gene id="10547231" protId="WHEAT100330"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Mixia osmundae (strain CBS 9802 / IAM 14324 / JCM 22182 / KY 12970)" NCBITaxId="764103">\n' +
+  '    <database name="Mixia osmundae from JGI" version="JGI; Mixos1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6929611" protId="MIXOS03639"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Brassica oleracea" NCBITaxId="109376">\n' +
+  '    <database name="Brassica oleracea from ENSEMBL plants v23" version="Ensembl Plants 23; v2.1; 8-OCT-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="11364698" protId="BRAOL40984"/>\n' +
+  '        <gene id="11336447" protId="BRAOL12733"/>\n' +
+  '        <gene id="11341034" protId="BRAOL17320"/>\n' +
+  '        <gene id="11335100" protId="BRAOL11386"/>\n' +
+  '        <gene id="11330234" protId="BRAOL06520"/>\n' +
+  '        <gene id="11363213" protId="BRAOL39499"/>\n' +
+  '        <gene id="11372777" protId="BRAOL49063"/>\n' +
+  '        <gene id="11377181" protId="BRAOL53467"/>\n' +
+  '        <gene id="11370688" protId="BRAOL46974"/>\n' +
+  '        <gene id="11333996" protId="BRAOL10282"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phaeosphaeria nodorum" NCBITaxId="13684">\n' +
+  '    <database name="Phaeosphaeria nodorum from JGI" version="JGI; Stano1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6311988" protId="PHAND05372"/>\n' +
+  '        <gene id="6313820" protId="PHAND07204"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Takifugu rubripes" NCBITaxId="31033">\n' +
+  '    <database name="Takifugu rubripes from ENSEMBL v70" version="Ensembl 70; FUGU4; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7125129" protId="TAKRU11762"/>\n' +
+  '        <gene id="7128661" protId="TAKRU15294"/>\n' +
+  '        <gene id="7115035" protId="TAKRU01668"/>\n' +
+  '        <gene id="7122011" protId="TAKRU08644"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pelodiscus sinensis" NCBITaxId="13735">\n' +
+  '    <database name="Pelodiscus sinensis from ENSEMBL v68" version="Ensembl 68; PelSin_1.0; 6-AUG-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8255638" protId="PELSI09598"/>\n' +
+  '        <gene id="8259215" protId="PELSI13175"/>\n' +
+  '        <gene id="8255596" protId="PELSI09556"/>\n' +
+  '        <gene id="8256850" protId="PELSI10810"/>\n' +
+  '        <gene id="8263764" protId="PELSI17724"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ochotona princeps" NCBITaxId="9978">\n' +
+  '    <database name="Ochotona princeps from ENSEMBL v70" version="Ensembl 70; pika; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7455980" protId="OCHPR11357"/>\n' +
+  '        <gene id="7449034" protId="OCHPR04411"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sorghum bicolor" NCBITaxId="4558">\n' +
+  '    <database name="Sorghum bicolor (L.) Moench complete genome from JGI" version="Sbi1_4, Filtered Models">\n' +
+  '      <genes>\n' +
+  '        <gene id="10659720" protId="SORBI00042"/>\n' +
+  '        <gene id="10668825" protId="SORBI09147"/>\n' +
+  '        <gene id="10661027" protId="SORBI01349"/>\n' +
+  '        <gene id="10681783" protId="SORBI22105"/>\n' +
+  '        <gene id="10692423" protId="SORBI32745"/>\n' +
+  '        <gene id="10693410" protId="SORBI33732"/>\n' +
+  '        <gene id="10668943" protId="SORBI09265"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Poecilia formosa" NCBITaxId="48698">\n' +
+  '    <database name="Poecilia formosa from ENSEMBL v77" version="Ensembl 77; PoeFor_5.1.2; 25-SEP-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7189689" protId="POEFO12861"/>\n' +
+  '        <gene id="7191776" protId="POEFO14948"/>\n' +
+  '        <gene id="7192875" protId="POEFO16047"/>\n' +
+  '        <gene id="7195779" protId="POEFO18951"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gasterosteus aculeatus" NCBITaxId="69293">\n' +
+  '    <database name="Gasterosteus aculeatus from ENSEMBL v70" version="Ensembl 70; BROADS1; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7107012" protId="GASAC15418"/>\n' +
+  '        <gene id="7112346" protId="GASAC20752"/>\n' +
+  '        <gene id="7112069" protId="GASAC20475"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Mustela putorius furo" NCBITaxId="9669">\n' +
+  '    <database name="Mustela putorius furo from ENSEMBL v69" version="Ensembl 69; MusPutFur1.0; 4-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7846791" protId="MUSPF02374"/>\n' +
+  '        <gene id="7847225" protId="MUSPF02808"/>\n' +
+  '        <gene id="7855267" protId="MUSPF10850"/>\n' +
+  '        <gene id="7853143" protId="MUSPF08726"/>\n' +
+  '        <gene id="7856785" protId="MUSPF12368"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Procavia capensis" NCBITaxId="9813">\n' +
+  '    <database name="Procavia capensis from ENSEMBL v70" version="Ensembl 70; proCap1; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7376473" protId="PROCA04768"/>\n' +
+  '        <gene id="7381518" protId="PROCA09813"/>\n' +
+  '        <gene id="7383318" protId="PROCA11613"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Wallemia sebi" NCBITaxId="148960">\n' +
+  '    <database name="Wallemia sebi from JGI" version="JGI; Walse1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6921922" protId="WALSE01217"/>\n' +
+  '        <gene id="6921578" protId="WALSE00873"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Choloepus hoffmanni" NCBITaxId="9358">\n' +
+  '    <database name="Choloepus hoffmanni from ENSEMBL v70" version="Ensembl 70; choHof1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8109072" protId="CHOHO05175"/>\n' +
+  '        <gene id="8114188" protId="CHOHO10291"/>\n' +
+  '        <gene id="8108454" protId="CHOHO04557"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Loxodonta africana" NCBITaxId="9785">\n' +
+  '    <database name="Loxodonta africana from ENSEMBL v70" version="Ensembl 70; loxAfr3; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7393479" protId="LOXAF05772"/>\n' +
+  '        <gene id="7408157" protId="LOXAF20450"/>\n' +
+  '        <gene id="7389582" protId="LOXAF01875"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ovis aries" NCBITaxId="9940">\n' +
+  '    <database name="Ovis aries from ENSEMBL v74" version="Ensembl 74; Oar_v3.1; 27-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="7960856" protId="SHEEP20289"/>\n' +
+  '        <gene id="7951347" protId="SHEEP10780"/>\n' +
+  '        <gene id="7960208" protId="SHEEP19641"/>\n' +
+  '        <gene id="7959484" protId="SHEEP18917"/>\n' +
+  '        <gene id="7958354" protId="SHEEP17787"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hordeum vulgare var. distichon" NCBITaxId="1288821">\n' +
+  '    <database name="Hordeum vulgare from ENSEMBL plants v16" version="Ensembl Plants 16; 220312v1; 24-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="10397431" protId="HORVD13539"/>\n' +
+  '        <gene id="10402855" protId="HORVD18963"/>\n' +
+  '        <gene id="10396281" protId="HORVD12389"/>\n' +
+  '        <gene id="10405887" protId="HORVD21995"/>\n' +
+  '        <gene id="10405164" protId="HORVD21272"/>\n' +
+  '        <gene id="10396270" protId="HORVD12378"/>\n' +
+  '        <gene id="10401038" protId="HORVD17146"/>\n' +
+  '        <gene id="10402431" protId="HORVD18539"/>\n' +
+  '        <gene id="10406491" protId="HORVD22599"/>\n' +
+  '        <gene id="10396603" protId="HORVD12711"/>\n' +
+  '        <gene id="10392825" protId="HORVD08933"/>\n' +
+  '        <gene id="10401268" protId="HORVD17376"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Capitella sp. 1" NCBITaxId="73382">\n' +
+  '    <database name="Capitella sp. I complete genome from JGI" version="v1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="9444206" protId="CAPI112826"/>\n' +
+  '        <gene id="9431807" protId="CAPI100427"/>\n' +
+  '        <gene id="9431806" protId="CAPI100426"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hypocrea atroviridis (strain ATCC 20476 / IMI 206040)" NCBITaxId="452589">\n' +
+  '    <database name="Hypocrea atroviridis from JGI" version="JGI; Triat2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6425295" protId="HYPAI01642"/>\n' +
+  '        <gene id="6431059" protId="HYPAI07406"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dendroctonus ponderosae" NCBITaxId="77166">\n' +
+  '    <database name="Dendroctonus ponderosae from ENSEMBL metazoa v23" version="Ensembl Metazoa 23; GCA_000355655.1; 24-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8762961" protId="DENPD07961"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila grimshawi" NCBITaxId="7222">\n' +
+  '    <database name="Drosophila grimshawi full genome from ENSEMBL Metazoa v5" version="Ensembl Metazoa v5; dgri_r1.3_FB2008_07; 15-MAY-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="8819141" protId="DROGR10959"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ixodes scapularis" NCBITaxId="6945">\n' +
+  '    <database name="Ixodes scapularis from Ensembl Metazoa release 2" version="Ensembl Metazoa release 2; IscaW1; 30-JUN-2009">\n' +
+  '      <genes>\n' +
+  '        <gene id="8635447" protId="IXOSC19148"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Passalora fulva" NCBITaxId="5499">\n' +
+  '    <database name="Passalora fulva from JGI" version="JGI; Clafu1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6265159" protId="PASFU06688"/>\n' +
+  '        <gene id="6259819" protId="PASFU01348"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phytophthora nicotianae" NCBITaxId="4790">\n' +
+  '    <database name="Phytophthora nicotianae (GCA_001483015) from Ensembl Protists 36" version="Ensembl Protists 36; ASM148301v1">\n' +
+  '      <genes>\n' +
+  '        <gene id="9872819" protId="PHYNI02950"/>\n' +
+  '        <gene id="9886377" protId="PHYNI16508"/>\n' +
+  '        <gene id="9880882" protId="PHYNI11013"/>\n' +
+  '        <gene id="9878596" protId="PHYNI08727"/>\n' +
+  '        <gene id="9883322" protId="PHYNI13453"/>\n' +
+  '        <gene id="9886376" protId="PHYNI16507"/>\n' +
+  '        <gene id="9883714" protId="PHYNI13845"/>\n' +
+  '        <gene id="9878597" protId="PHYNI08728"/>\n' +
+  '        <gene id="9880880" protId="PHYNI11011"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Physcomitrella patens subsp. patens" NCBITaxId="3218">\n' +
+  '    <database name="Physcomitrella patens from ENSEMBL plants v21" version="Ensembl Plants 21; ASM242v1; 4-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10078761" protId="PHYPA30259"/>\n' +
+  '        <gene id="10055354" protId="PHYPA06852"/>\n' +
+  '        <gene id="10073775" protId="PHYPA25273"/>\n' +
+  '        <gene id="10076891" protId="PHYPA28389"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila ananassae" NCBITaxId="7217">\n' +
+  '    <database name="Drosophila ananassae from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000005115.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="9064609" protId="DROAN08724"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Stereum hirsutum (strain FP-91666)" NCBITaxId="721885">\n' +
+  '    <database name="Stereum hirsutum from JGI" version="JGI; Stehi1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6803732" protId="STEHR05644"/>\n' +
+  '        <gene id="6801952" protId="STEHR03864"/>\n' +
+  '        <gene id="6798902" protId="STEHR00814"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila bipectinata" NCBITaxId="42026">\n' +
+  '    <database name="Drosophila bipectinata from modENCODE" version="modENCODE; 0.5.3">\n' +
+  '      <genes>\n' +
+  '        <gene id="9080050" protId="DROBP09256"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Trametes versicolor (strain FP-101664)" NCBITaxId="717944">\n' +
+  '    <database name="Trametes versicolor from JGI" version="JGI; Trave1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6722832" protId="TRAVS11712"/>\n' +
+  '        <gene id="6711992" protId="TRAVS00872"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Polysphondylium pallidum (strain ATCC 26659 / Pp 5 / PN500)" NCBITaxId="670386">\n' +
+  '    <database name="Polysphondylium pallidum PN500 from Ensembl Protists 36" version="Ensembl Protists 36; PolPal_Dec2009">\n' +
+  '      <genes>\n' +
+  '        <gene id="5907023" protId="POLPP02544"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Amborella trichopoda" NCBITaxId="13333">\n' +
+  '    <database name="Amborella trichopoda from ENSEMBL plants v23" version="Ensembl Plants 23; GCA_000471905.1; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="11586553" protId="AMBTC22043"/>\n' +
+  '        <gene id="11583722" protId="AMBTC19212"/>\n' +
+  '        <gene id="11588912" protId="AMBTC24402"/>\n' +
+  '        <gene id="11576518" protId="AMBTC12008"/>\n' +
+  '        <gene id="11574451" protId="AMBTC09941"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Coprinopsis cinerea" NCBITaxId="5346">\n' +
+  '    <database name="Coprinopsis cinerea from JGI" version="JGI; Copci1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6849249" protId="COPCI15059"/>\n' +
+  '        <gene id="6840895" protId="COPCI06705"/>\n' +
+  '        <gene id="6840482" protId="COPCI06292"/>\n' +
+  '        <gene id="6844915" protId="COPCI10725"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus aculeatus" NCBITaxId="5053">\n' +
+  '    <database name="Aspergillus aculeatus from JGI" version="JGI; Aspac1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6121654" protId="ASPAC07474"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Macropus eugenii" NCBITaxId="9315">\n' +
+  '    <database name="Macropus eugenii from ENSEMBL v70" version="Ensembl 70; Meug_1.0; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8160662" protId="MACEU08255"/>\n' +
+  '        <gene id="8164653" protId="MACEU12246"/>\n' +
+  '        <gene id="8166892" protId="MACEU14485"/>\n' +
+  '        <gene id="8156404" protId="MACEU03997"/>\n' +
+  '        <gene id="8158554" protId="MACEU06147"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lepisosteus oculatus" NCBITaxId="7918">\n' +
+  '    <database name="Lepisosteus oculatus from ENSEMBL v74" version="Ensembl 74; LepOcu1; 27-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="7078432" protId="LEPOC05731"/>\n' +
+  '        <gene id="7088836" protId="LEPOC16135"/>\n' +
+  '        <gene id="7084615" protId="LEPOC11914"/>\n' +
+  '        <gene id="7083932" protId="LEPOC11231"/>\n' +
+  '        <gene id="7073579" protId="LEPOC00878"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ciona savignyi" NCBITaxId="51511">\n' +
+  '    <database name="Ciona savignyi from ENSEMBL v70" version="Ensembl 70; CSAV2.0; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8320601" protId="CIOSA02423"/>\n' +
+  '        <gene id="8323672" protId="CIOSA05494"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryctolagus cuniculus" NCBITaxId="9986">\n' +
+  '    <database name="Oryctolagus cuniculus from ENSEMBL v84" version="Ensembl 84; OryCun2.0; 24-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="7439084" protId="RABIT13828"/>\n' +
+  '        <gene id="7425992" protId="RABIT00736"/>\n' +
+  '        <gene id="7428198" protId="RABIT02942"/>\n' +
+  '        <gene id="7441572" protId="RABIT16316"/>\n' +
+  '        <gene id="7438663" protId="RABIT13407"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Anolis carolinensis" NCBITaxId="28377">\n' +
+  '    <database name="Anolis carolinensis from ENSEMBL v70" version="Ensembl 70; AnoCar2.0; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8265942" protId="ANOCA01584"/>\n' +
+  '        <gene id="8269125" protId="ANOCA04767"/>\n' +
+  '        <gene id="8279469" protId="ANOCA15111"/>\n' +
+  '        <gene id="8269599" protId="ANOCA05241"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Neosartorya fischeri (strain ATCC 1020 / DSM 3700 / CBS 544.65 / FGSC A1164 / JCM 1740 / NRRL 181 / WB 181)" NCBITaxId="331117">\n' +
+  '    <database name="Neosartorya fischeri from JGI" version="JGI; Neofi1; 15-AUG-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6144379" protId="NEOFI10259"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tursiops truncatus" NCBITaxId="9739">\n' +
+  '    <database name="Tursiops truncatus from ENSEMBL v70" version="Ensembl 70; turTru1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7913277" protId="TURTR09516"/>\n' +
+  '        <gene id="7905945" protId="TURTR02184"/>\n' +
+  '        <gene id="7914408" protId="TURTR10647"/>\n' +
+  '        <gene id="7908367" protId="TURTR04606"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hyaloperonospora arabidopsidis (strain Emoy2)" NCBITaxId="559515">\n' +
+  '    <database name="Hyaloperonospora arabidopsidis from ENSEMBL protists v31" version="Ensembl Protists 31; HyaAraEmoy2_2.0; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9846007" protId="HYAAE07223"/>\n' +
+  '        <gene id="9850819" protId="HYAAE12035"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Melitaea cinxia" NCBITaxId="113334">\n' +
+  '    <database name="Melitaea cinxia from ENSEMBL metazoa v23" version="Ensembl Metazoa 23; MelCinx1.0; 24-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8751321" protId="MELCN12949"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lucilia cuprina" NCBITaxId="7375">\n' +
+  '    <database name="Lucilia cuprina from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; GCA_001187945.1; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9105176" protId="LUCCU05643"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Botryotinia fuckeliana (strain B05.10)" NCBITaxId="332648">\n' +
+  '    <database name="Botrytis cinerea full genome from the BROAD Institute" version="Release 1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6361639" protId="BOTFB03972"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Punctularia strigosozonata (strain HHB-11173)" NCBITaxId="741275">\n' +
+  '    <database name="Punctularia strigosozonata from JGI" version="JGI; Punst1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6669180" protId="PUNST01437"/>\n' +
+  '        <gene id="6668783" protId="PUNST01040"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sorex araneus" NCBITaxId="42254">\n' +
+  '    <database name="Sorex araneus from ENSEMBL v70" version="Ensembl 70; COMMON_SHREW1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8054842" protId="SORAR07979"/>\n' +
+  '        <gene id="8051674" protId="SORAR04811"/>\n' +
+  '        <gene id="8055267" protId="SORAR08404"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Nematostella vectensis" NCBITaxId="45351">\n' +
+  '    <database name="Nematostella vectensis complete genome from JGI" version="Nemve1">\n' +
+  '      <genes>\n' +
+  '        <gene id="9624204" protId="NEMVE13814"/>\n' +
+  '        <gene id="9618969" protId="NEMVE08579"/>\n' +
+  '        <gene id="9616082" protId="NEMVE05692"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Reticulomyxa filosa" NCBITaxId="46433">\n' +
+  '    <database name="Reticulomyxa filosa from ENSEMBL protists v31" version="Ensembl Protists 31; Reti_assembly1_0; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9759552" protId="RETFI13955"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila melanogaster" NCBITaxId="7227">\n' +
+  '    <database name="Drosophila melanogaster from Ensembl 90" version="Ensembl 90; BDGP6">\n' +
+  '      <genes>\n' +
+  '        <gene id="8917325" protId="DROME06470"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pongo abelii" NCBITaxId="9601">\n' +
+  '    <database name="Pongo abelii from ENSEMBL v70" version="Ensembl 70; PPYG2; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7702286" protId="PONAB04279"/>\n' +
+  '        <gene id="7711873" protId="PONAB13866"/>\n' +
+  '        <gene id="7714722" protId="PONAB16715"/>\n' +
+  '        <gene id="7699612" protId="PONAB01605"/>\n' +
+  '        <gene id="7715016" protId="PONAB17009"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza sativa subsp. indica" NCBITaxId="39946">\n' +
+  '    <database name="Oryza Indica from ENSEMBL plants v21" version="Ensembl Plants 21; ASM465v1; 4-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10308903" protId="ORYSI26279"/>\n' +
+  '        <gene id="10308475" protId="ORYSI25851"/>\n' +
+  '        <gene id="10284451" protId="ORYSI01827"/>\n' +
+  '        <gene id="10286786" protId="ORYSI04162"/>\n' +
+  '        <gene id="10286119" protId="ORYSI03495"/>\n' +
+  '        <gene id="10291530" protId="ORYSI08906"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Chlamydomonas reinhardtii" NCBITaxId="3055">\n' +
+  '    <database name="Chlamydomonas reinhardtii from Phytozome" version="v4.3">\n' +
+  '      <genes>\n' +
+  '        <gene id="9968880" protId="CHLRE13218"/>\n' +
+  '        <gene id="9968246" protId="CHLRE12584"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Bombyx mori" NCBITaxId="7091">\n' +
+  '    <database name="Bombyx mori from SilkDB" version="v2.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="8708522" protId="BOMMO13781"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Anas platyrhynchos" NCBITaxId="8839">\n' +
+  '    <database name="Anas platyrhynchos from ENSEMBL v73" version="Ensembl 73; BGI_duck_1.0; 24-AUG-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8179305" protId="ANAPL11636"/>\n' +
+  '        <gene id="8175841" protId="ANAPL08172"/>\n' +
+  '        <gene id="8173999" protId="ANAPL06330"/>\n' +
+  '        <gene id="8175740" protId="ANAPL08071"/>\n' +
+  '        <gene id="8178730" protId="ANAPL11061"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Linepithema humile" NCBITaxId="83485">\n' +
+  '    <database name="Linepithema humile from Refseq" version="Refseq; Lhum_UMD_V04; GCF_000217595.1; 27-APR-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9197915" protId="LINHU01350"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza rufipogon" NCBITaxId="4529">\n' +
+  '    <database name="Oryza rufipogon from ENSEMBL plants v23" version="Ensembl Plants 23; PRJEB4137; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="10253271" protId="ORYRU09043"/>\n' +
+  '        <gene id="10271050" protId="ORYRU26822"/>\n' +
+  '        <gene id="10245951" protId="ORYRU01723"/>\n' +
+  '        <gene id="10248309" protId="ORYRU04081"/>\n' +
+  '        <gene id="10270612" protId="ORYRU26384"/>\n' +
+  '        <gene id="10247621" protId="ORYRU03393"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Camponotus floridanus" NCBITaxId="104421">\n' +
+  '    <database name="Camponotus floridanus unplaced genomic scaffold scaffold4250, whole genome shotgun sequence." version="20-SEP-2010 (Rel. 106, Last updated, Version 1)">\n' +
+  '      <genes>\n' +
+  '        <gene id="9238036" protId="CAMFO07538"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Penicillium chrysogenum" NCBITaxId="5076">\n' +
+  '    <database name="Penicillium chrysogenum from JGI" version="JGI; Pench1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6230548" protId="PENCH09257"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Nomascus leucogenys" NCBITaxId="61853">\n' +
+  '    <database name="Nomascus leucogenys from ENSEMBL v80" version="Ensembl 80; Nleu1.0; 15-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="7717723" protId="NOMLE01296"/>\n' +
+  '        <gene id="7726807" protId="NOMLE10380"/>\n' +
+  '        <gene id="7724978" protId="NOMLE08551"/>\n' +
+  '        <gene id="7718597" protId="NOMLE02170"/>\n' +
+  '        <gene id="7730844" protId="NOMLE14417"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lingula unguis" NCBITaxId="7574">\n' +
+  '    <database name="Lingula unguis from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; GCA_001039355.1; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9513584" protId="LINUN19317"/>\n' +
+  '        <gene id="9520417" protId="LINUN26150"/>\n' +
+  '        <gene id="9522389" protId="LINUN28122"/>\n' +
+  '        <gene id="9522254" protId="LINUN27987"/>\n' +
+  '        <gene id="9514934" protId="LINUN20667"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ornithorhynchus anatinus" NCBITaxId="9258">\n' +
+  '    <database name="Ornithorhynchus anatinus from ENSEMBL v49" version="OANA5; Ensembl 49; 20-FEB-2008">\n' +
+  '      <genes>\n' +
+  '        <gene id="7355117" protId="ORNAN03142"/>\n' +
+  '        <gene id="7370927" protId="ORNAN18952"/>\n' +
+  '        <gene id="7365270" protId="ORNAN13295"/>\n' +
+  '        <gene id="7367098" protId="ORNAN15123"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phytophthora parasitica" NCBITaxId="4792">\n' +
+  '    <database name="Phytophthora parasitica (GCA_000509505) from Ensembl Protists 36" version="Ensembl Protists 36; Phyt_para_CHvinca01_V1">\n' +
+  '      <genes>\n' +
+  '        <gene id="9892974" protId="PHYPR05757"/>\n' +
+  '        <gene id="9906948" protId="PHYPR19731"/>\n' +
+  '        <gene id="9906949" protId="PHYPR19732"/>\n' +
+  '        <gene id="9893600" protId="PHYPR06383"/>\n' +
+  '        <gene id="9893598" protId="PHYPR06381"/>\n' +
+  '        <gene id="9897588" protId="PHYPR10371"/>\n' +
+  '        <gene id="9893676" protId="PHYPR06459"/>\n' +
+  '        <gene id="9897586" protId="PHYPR10369"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Puccinia graminis f. sp. tritici (strain CRL 75-36-700-3 / race SCCL)" NCBITaxId="418459">\n' +
+  '    <database name="Puccinia graministritici from ENSEMBL Fungi v8" version="Ensembl Fungi v8; BROAD1; 21-JAN-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="6968302" protId="PUCGT15183"/>\n' +
+  '        <gene id="6953939" protId="PUCGT00820"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sus scrofa" NCBITaxId="9823">\n' +
+  '    <database name="Sus scrofa from ENSEMBL v86" version="Ensembl 86; Sscrofa10.2; 14-SEP-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="7979882" protId="PIGXX18231"/>\n' +
+  '        <gene id="7982476" protId="PIGXX20825"/>\n' +
+  '        <gene id="7980925" protId="PIGXX19274"/>\n' +
+  '        <gene id="7982415" protId="PIGXX20764"/>\n' +
+  '        <gene id="7962641" protId="PIGXX00990"/>\n' +
+  '        <gene id="7981236" protId="PIGXX19585"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Phaeosphaeria nodorum (strain SN15 / ATCC MYA-4574 / FGSC 10173)" NCBITaxId="321614">\n' +
+  '    <database name="Stagonospora nodorum (Phaeosphaeria nodorum) strain SN15 full genome from the BROAD Institute" version="Release 1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6325203" protId="PHANO02612"/>\n' +
+  '        <gene id="6322593" protId="PHANO00002"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Blumeria graminis" NCBITaxId="34373">\n' +
+  '    <database name="Blumeria graminis from ENSEMBL fungi v28" version="Ensembl Fungi 28; EF1; 29-JUL-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="6357346" protId="BLUGR06137"/>\n' +
+  '        <gene id="6353686" protId="BLUGR02477"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila takahashii" NCBITaxId="29030">\n' +
+  '    <database name="Drosophila takahashii from modENCODE" version="modENCODE; 0.5.3">\n' +
+  '      <genes>\n' +
+  '        <gene id="9014181" protId="DROTK02845"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dictyostelium purpureum" NCBITaxId="5786">\n' +
+  '    <database name="Dictyostelium purpureum from JGI" version="Dicpu1; 12-Feb-2007">\n' +
+  '      <genes>\n' +
+  '        <gene id="5902140" protId="DICPU09978"/>\n' +
+  '        <gene id="5904342" protId="DICPU12180"/>\n' +
+  '        <gene id="5896462" protId="DICPU04300"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Zootermopsis nevadensis" NCBITaxId="136037">\n' +
+  '    <database name="Zootermopsis nevadensis from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000696155.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="9384480" protId="ZOONE13351"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Caenorhabditis japonica" NCBITaxId="281687">\n' +
+  '    <database name="Caenorhabditis japonica full genome from Wormbase 196" version="Wormbase WS196; 31-Oct-2008">\n' +
+  '      <genes>\n' +
+  '        <gene id="8487534" protId="CAEJA07494"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Papio anubis" NCBITaxId="9555">\n' +
+  '    <database name="Papio anubis from ENSEMBL v77" version="Ensembl 77; PapAnu2.0; 26-SEP-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7625330" protId="PAPAN18119"/>\n' +
+  '        <gene id="7620802" protId="PAPAN13591"/>\n' +
+  '        <gene id="7622922" protId="PAPAN15711"/>\n' +
+  '        <gene id="7625605" protId="PAPAN18394"/>\n' +
+  '        <gene id="7613302" protId="PAPAN06091"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Monosiga brevicollis" NCBITaxId="81824">\n' +
+  '    <database name="Monosiga brevicollis complete genome from JGI" version="v1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6062761" protId="MONBE08379"/>\n' +
+  '        <gene id="6061603" protId="MONBE07221"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Triticum urartu" NCBITaxId="4572">\n' +
+  '    <database name="Triticum urartu from ENSEMBL plants v19" version="Ensembl Plants 19; GCA_000347455.1; 26-JUN-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10596146" protId="TRIUA10596"/>\n' +
+  '        <gene id="10595731" protId="TRIUA10181"/>\n' +
+  '        <gene id="10600466" protId="TRIUA14916"/>\n' +
+  '        <gene id="10593003" protId="TRIUA07453"/>\n' +
+  '        <gene id="10590884" protId="TRIUA05334"/>\n' +
+  '        <gene id="10599200" protId="TRIUA13650"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Arabis alpina" NCBITaxId="50452">\n' +
+  '    <database name="Arabis alpina from ENA" version="ENA; A_alpina_V4; GCA_000733195.1">\n' +
+  '      <genes>\n' +
+  '        <gene id="11171536" protId="ARAAL10263"/>\n' +
+  '        <gene id="11180896" protId="ARAAL19623"/>\n' +
+  '        <gene id="11163937" protId="ARAAL02664"/>\n' +
+  '        <gene id="11170099" protId="ARAAL08826"/>\n' +
+  '        <gene id="11172818" protId="ARAAL11545"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Thalassiosira pseudonana" NCBITaxId="296543">\n' +
+  '    <database name="Thalassiosira pseudonana from ENSEMBL protists v31" version="Ensembl Protists 31; ASM14940v1; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9818278" protId="THAPS00139"/>\n' +
+  '        <gene id="9824326" protId="THAPS06187"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pteropus vampyrus" NCBITaxId="132908">\n' +
+  '    <database name="Pteropus vampyrus from ENSEMBL v70" version="Ensembl 70; pteVam1; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8000540" protId="PTEVA04974"/>\n' +
+  '        <gene id="7999122" protId="PTEVA03556"/>\n' +
+  '        <gene id="8010384" protId="PTEVA14818"/>\n' +
+  '        <gene id="8004297" protId="PTEVA08731"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Bigelowiella natans (strain CCMP2755)" NCBITaxId="753081">\n' +
+  '    <database name="Bigelowiella natans from ENSEMBL protists v32" version="Ensembl Protists 32; GCA_000320545.1; 3-AUG-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9741320" protId="BIGNC17195"/>\n' +
+  '        <gene id="9730476" protId="BIGNC06351"/>\n' +
+  '        <gene id="9741322" protId="BIGNC17197"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus flavus (strain ATCC 200026 / FGSC A1120 / NRRL 3357 / JCM 12722 / SRRC 167)" NCBITaxId="332952">\n' +
+  '    <database name="Aspergillus flavus from ENSEMBL fungi v16" version="Ensembl Fungi 16; assembly; 17-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6155908" protId="ASPFN11386"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Fomitiporia mediterranea (strain MF3/22)" NCBITaxId="694068">\n' +
+  '    <database name="Fomitiporia mediterranea from JGI" version="JGI; Fomme1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6699046" protId="FOMME08026"/>\n' +
+  '        <gene id="6695474" protId="FOMME04454"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Capsaspora owczarzaki (strain ATCC 30864)" NCBITaxId="595528">\n' +
+  '    <database name="Capsaspora owczarzaki ATCC 30864" version="GG697242.1  GI:255680505">\n' +
+  '      <genes>\n' +
+  '        <gene id="9710684" protId="CAPO303615"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Brassica napus" NCBITaxId="3708">\n' +
+  '    <database name="Brassica napus from Genoscope" version="Darmor-bzh; v5">\n' +
+  '      <genes>\n' +
+  '        <gene id="11237239" protId="BRANA11655"/>\n' +
+  '        <gene id="11247898" protId="BRANA22314"/>\n' +
+  '        <gene id="11303930" protId="BRANA78346"/>\n' +
+  '        <gene id="11311305" protId="BRANA85721"/>\n' +
+  '        <gene id="11256867" protId="BRANA31283"/>\n' +
+  '        <gene id="11314835" protId="BRANA89251"/>\n' +
+  '        <gene id="11276326" protId="BRANA50742"/>\n' +
+  '        <gene id="11229807" protId="BRANA04223"/>\n' +
+  '        <gene id="11264976" protId="BRANA39392"/>\n' +
+  '        <gene id="11237240" protId="BRANA11656"/>\n' +
+  '        <gene id="11260395" protId="BRANA34811"/>\n' +
+  '        <gene id="11234003" protId="BRANA08419"/>\n' +
+  '        <gene id="11278961" protId="BRANA53377"/>\n' +
+  '        <gene id="11309342" protId="BRANA83758"/>\n' +
+  '        <gene id="11302653" protId="BRANA77069"/>\n' +
+  '        <gene id="11277671" protId="BRANA52087"/>\n' +
+  '        <gene id="11263537" protId="BRANA37953"/>\n' +
+  '        <gene id="11246731" protId="BRANA21147"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Microcebus murinus" NCBITaxId="30608">\n' +
+  '    <database name="Microcebus murinus from ENSEMBL v70" version="Ensembl 70; micMur1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7779582" protId="MICMU06885"/>\n' +
+  '        <gene id="7786451" protId="MICMU13754"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila sechellia" NCBITaxId="7238">\n' +
+  '    <database name="Drosophila sechellia from ENSEMBL metazoa v23" version="Ensembl Metazoa 23; dsec_caf1; 24-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8992443" protId="DROSE12387"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tetranychus urticae" NCBITaxId="32264">\n' +
+  '    <database name="Tetranychus urticae from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000239435.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8606415" protId="TETUR08135"/>\n' +
+  '        <gene id="8615522" protId="TETUR17242"/>\n' +
+  '        <gene id="8615408" protId="TETUR17128"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aureococcus anophagefferens" NCBITaxId="44056">\n' +
+  '    <database name="Aureococcus anophagefferens from EnsemblProtist" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="9953106" protId="AURAN08669"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Trichoplax adhaerens" NCBITaxId="10228">\n' +
+  '    <database name="Trichoplax adhaerens complete genome from JGI" version="Grell-BS-1999 v1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="9677412" protId="TRIAD10273"/>\n' +
+  '        <gene id="9669959" protId="TRIAD02820"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Batrachochytrium dendrobatidis" NCBITaxId="109871">\n' +
+  '    <database name="Batrachochytrium dendrobatidis from JGI" version="JGI; Batde5; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6075596" protId="BATDE00342"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dichomitus squalens (strain LYAD-421)" NCBITaxId="732165">\n' +
+  '    <database name="Dichomitus squalens from JGI" version="JGI; Dicsq1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6779399" protId="DICSQ05717"/>\n' +
+  '        <gene id="6774105" protId="DICSQ00423"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Penicillium rubens (strain ATCC 28089 / DSM 1075 / NRRL 1951 / Wisconsin 54-1255)" NCBITaxId="500485">\n' +
+  '    <database name="Penicillium chrysogenum Wisconsin 54-1255" version="NS_000201.1  GI:256353024">\n' +
+  '      <genes>\n' +
+  '        <gene id="6242652" protId="PENRW09965"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Neurospora tetrasperma (strain FGSC 2509 / P0656)" NCBITaxId="510952">\n' +
+  '    <database name="Neurospora tetrasperma from JGI" version="JGI; Neute_matA2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6551654" protId="NEUT908172"/>\n' +
+  '        <gene id="6549890" protId="NEUT906408"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hypsibius dujardini" NCBITaxId="232323">\n' +
+  '    <database name="Hypsibius dujardini" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="9392238" protId="HYPDU06773"/>\n' +
+  '        <gene id="9394239" protId="HYPDU08774"/>\n' +
+  '        <gene id="9397874" protId="HYPDU12409"/>\n' +
+  '        <gene id="9386686" protId="HYPDU01221"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Magnaporthe grisea" NCBITaxId="148305">\n' +
+  '    <database name="Magnaporthe grisea full genome from the BROAD Institute" version="Release 5.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6515950" protId="MAGGR01761"/>\n' +
+  '        <gene id="6522682" protId="MAGGR08493"/>\n' +
+  '        <gene id="6516617" protId="MAGGR02428"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza sativa subsp. japonica" NCBITaxId="39947">\n' +
+  '    <database name="Oryza sativa from ENSEMBL plants v27" version="Ensembl Plants 27; IRGSP-1; 26-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="10346604" protId="ORYSJ23616"/>\n' +
+  '        <gene id="10326046" protId="ORYSJ03058"/>\n' +
+  '        <gene id="10326705" protId="ORYSJ03717"/>\n' +
+  '        <gene id="10324561" protId="ORYSJ01573"/>\n' +
+  '        <gene id="10347006" protId="ORYSJ24018"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Homo sapiens" NCBITaxId="9606">\n' +
+  '    <database name="Homo sapiens from ENSEMBL v86" version="Ensembl 86; GRCh38; 13-SEP-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="7653682" protId="HUMAN05320"/>\n' +
+  '        <gene id="7678090" protId="HUMAN29728"/>\n' +
+  '        <gene id="7674130" protId="HUMAN25768"/>\n' +
+  '        <gene id="7678477" protId="HUMAN30115"/>\n' +
+  '        <gene id="7658071" protId="HUMAN09709"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Equus caballus" NCBITaxId="9796">\n' +
+  '    <database name="Equus caballus from ENSEMBL v70" version="Ensembl 70; EquCab2; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8079824" protId="HORSE19865"/>\n' +
+  '        <gene id="8074139" protId="HORSE14180"/>\n' +
+  '        <gene id="8060904" protId="HORSE00945"/>\n' +
+  '        <gene id="8077688" protId="HORSE17729"/>\n' +
+  '        <gene id="8079514" protId="HORSE19555"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Talaromyces stipitatus (strain ATCC 10500 / CBS 375.48 / QM 6759 / NRRL 1006)" NCBITaxId="441959">\n' +
+  '    <database name="Talaromyces stipitatus ATCC 10500 from Ensembl Fungi 34" version="Ensembl Fungi 34; JCVI-TSTA1-3.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6247861" protId="TALSN02404"/>\n' +
+  '        <gene id="6255939" protId="TALSN10482"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Batrachochytrium dendrobatidis (strain JAM81 / FGSC 10211)" NCBITaxId="684364">\n' +
+  '    <database name="Batrachochytrium dendrobatidis JAM81 from JGI" version="Dicpu5; 02-Mar-2009">\n' +
+  '      <genes>\n' +
+  '        <gene id="6084198" protId="BATDJ00342"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila eugracilis" NCBITaxId="29029">\n' +
+  '    <database name="Drosophila eugracilis from modENCODE" version="modENCODE; 0.5.3">\n' +
+  '      <genes>\n' +
+  '        <gene id="8868678" protId="DROEU00376"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Emericella nidulans (strain FGSC A4 / ATCC 38163 / CBS 112.46 / NRRL 194 / M139)" NCBITaxId="227321">\n' +
+  '    <database name="Emericella nidulans full genome from ENSEMBL Fungi v4" version="Ensembl Fungi v4; Eurofung Sep 2006; 17-FEB-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="6203779" protId="EMENI02628"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Danaus plexippus" NCBITaxId="13037">\n' +
+  '    <database name="Danaus plexippus from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; DanPle_1.0; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8720413" protId="DANPL11095"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gorilla gorilla gorilla" NCBITaxId="9595">\n' +
+  '    <database name="Gorilla gorilla from ENSEMBL v75" version="Ensembl 75; gorGor3.1; 8-FEB-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7633520" protId="GORGO06980"/>\n' +
+  '        <gene id="7644626" protId="GORGO18086"/>\n' +
+  '        <gene id="7647946" protId="GORGO21406"/>\n' +
+  '        <gene id="7630574" protId="GORGO04034"/>\n' +
+  '        <gene id="7647630" protId="GORGO21090"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lepeophtheirus salmonis" NCBITaxId="72036">\n' +
+  '    <database name="Lepeophtheirus salmonis from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; LSalAtl2s; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="8683616" protId="LEPSM01887"/>\n' +
+  '        <gene id="8694634" protId="LEPSM12905"/>\n' +
+  '        <gene id="8685530" protId="LEPSM03801"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Otolemur garnettii" NCBITaxId="30611">\n' +
+  '    <database name="Otolemur garnettii from ENSEMBL v70" version="Ensembl 70; OtoGar3; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7807839" protId="OTOGA18919"/>\n' +
+  '        <gene id="7794141" protId="OTOGA05221"/>\n' +
+  '        <gene id="7792409" protId="OTOGA03489"/>\n' +
+  '        <gene id="7794192" protId="OTOGA05272"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Rhodnius prolixus" NCBITaxId="13249">\n' +
+  '    <database name="Rhodnius prolixus from ENSEMBL metazoa v27" version="Ensembl Metazoa 27; RproC1; 2-JUN-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9319349" protId="RHOPR07990"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Neosartorya fumigata (strain ATCC MYA-4609 / Af293 / CBS 101355 / FGSC A1100)" NCBITaxId="330879">\n' +
+  '    <database name="Aspergillus fumigatus from ENSEMBL fungi v21" version="Ensembl Fungi 21; CADRE; 5-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="6219933" protId="ASPFU08272"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Brachypodium distachyon" NCBITaxId="15368">\n' +
+  '    <database name="Brachypodium distachyon from ENSEMBL plants v21" version="Ensembl Plants 21; v1.0; 6-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10367248" protId="BRADI10035"/>\n' +
+  '        <gene id="10370089" protId="BRADI12876"/>\n' +
+  '        <gene id="10378554" protId="BRADI21341"/>\n' +
+  '        <gene id="10369543" protId="BRADI12330"/>\n' +
+  '        <gene id="10366268" protId="BRADI09055"/>\n' +
+  '        <gene id="10366884" protId="BRADI09671"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Emiliania huxleyi" NCBITaxId="280463">\n' +
+  '    <database name="Emiliania huxleyi CCMP1516 from JGI" version="v1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="6010597" protId="EMIHU03238"/>\n' +
+  '        <gene id="6033955" protId="EMIHU26596"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Zea mays" NCBITaxId="4577">\n' +
+  '    <database name="Zea mays from ENSEMBL plants v27" version="Ensembl Plants 27; AGPv3; 27-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="10711213" protId="MAIZE16088"/>\n' +
+  '        <gene id="10709411" protId="MAIZE14286"/>\n' +
+  '        <gene id="10713428" protId="MAIZE18303"/>\n' +
+  '        <gene id="10729394" protId="MAIZE34269"/>\n' +
+  '        <gene id="10711449" protId="MAIZE16324"/>\n' +
+  '        <gene id="10697414" protId="MAIZE02289"/>\n' +
+  '        <gene id="10732206" protId="MAIZE37081"/>\n' +
+  '        <gene id="10732136" protId="MAIZE37011"/>\n' +
+  '        <gene id="10727303" protId="MAIZE32178"/>\n' +
+  '        <gene id="10709409" protId="MAIZE14284"/>\n' +
+  '        <gene id="10709407" protId="MAIZE14282"/>\n' +
+  '        <gene id="10712885" protId="MAIZE17760"/>\n' +
+  '        <gene id="10717804" protId="MAIZE22679"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Heterobasidion annosum" NCBITaxId="13563">\n' +
+  '    <database name="Heterobasidion annosum from JGI" version="JGI; Hetan1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6797054" protId="HETAN11128"/>\n' +
+  '        <gene id="6790375" protId="HETAN04449"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ciona intestinalis" NCBITaxId="7719">\n' +
+  '    <database name="Ciona intestinalis from ENSEMBL v70" version="Ensembl 70; KH; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8310337" protId="CIOIN08659"/>\n' +
+  '        <gene id="8310217" protId="CIOIN08539"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lottia gigantea" NCBITaxId="225164">\n' +
+  '    <database name="Lottia gigantea complete genome from JGI" version="Sbi1_4, Filtered Models">\n' +
+  '      <genes>\n' +
+  '        <gene id="9595083" protId="LOTGI08207"/>\n' +
+  '        <gene id="9605200" protId="LOTGI18324"/>\n' +
+  '        <gene id="9596235" protId="LOTGI09359"/>\n' +
+  '        <gene id="9597528" protId="LOTGI10652"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Eragrostis tef" NCBITaxId="110835">\n' +
+  '    <database name="Eragrostis tef from tef-research" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="10657436" protId="ERATE39251"/>\n' +
+  '        <gene id="10648094" protId="ERATE29909"/>\n' +
+  '        <gene id="10625406" protId="ERATE07221"/>\n' +
+  '        <gene id="10659496" protId="ERATE41311"/>\n' +
+  '        <gene id="10620455" protId="ERATE02270"/>\n' +
+  '        <gene id="10621238" protId="ERATE03053"/>\n' +
+  '        <gene id="10645125" protId="ERATE26940"/>\n' +
+  '        <gene id="10646638" protId="ERATE28453"/>\n' +
+  '        <gene id="10644535" protId="ERATE26350"/>\n' +
+  '        <gene id="10636429" protId="ERATE18244"/>\n' +
+  '        <gene id="10654700" protId="ERATE36515"/>\n' +
+  '        <gene id="10620333" protId="ERATE02148"/>\n' +
+  '        <gene id="10635498" protId="ERATE17313"/>\n' +
+  '        <gene id="10649846" protId="ERATE31661"/>\n' +
+  '        <gene id="10646637" protId="ERATE28452"/>\n' +
+  '        <gene id="10639236" protId="ERATE21051"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Harpegnathos saltator" NCBITaxId="610380">\n' +
+  '    <database name="Harpegnathos saltator unplaced genomic scaffold C20573862, whole genome shotgun sequence." version="20-SEP-2010 (Rel. 106, Last updated, Version 1)">\n' +
+  '      <genes>\n' +
+  '        <gene id="9283492" protId="HARSA04104"/>\n' +
+  '        <gene id="9293572" protId="HARSA14184"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Fusarium oxysporum f. sp. lycopersici (strain 4287 / CBS 123668 / FGSC 9935 / NRRL 34936)" NCBITaxId="426428">\n' +
+  '    <database name="Fusarium oxysporum from ENSEMBL fungi v16" version="Ensembl Fungi 16; FO2; 19-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6458800" protId="FUSO401755"/>\n' +
+  '        <gene id="6473130" protId="FUSO416085"/>\n' +
+  '        <gene id="6462303" protId="FUSO405258"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Cerapachys biroi" NCBITaxId="2015173">\n' +
+  '    <database name="Cerapachys biroi unplaced genomic scaffold scaffold1, whole genome shotgun sequence." version="30-APR-2014 (Rel. 120, Last updated, Version 1)">\n' +
+  '      <genes>\n' +
+  '        <gene id="9219480" protId="CERBI05285"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gloeophyllum trabeum" NCBITaxId="104355">\n' +
+  '    <database name="Gloeophyllum trabeum from JGI" version="JGI; Glotr1_1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6688773" protId="GLOTR09535"/>\n' +
+  '        <gene id="6679936" protId="GLOTR00698"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Medicago truncatula" NCBITaxId="3880">\n' +
+  '    <database name="Medicago truncatula from ENSEMBL plants v18" version="Ensembl Plants 18; GCA_000219495.1; 8-APR-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="11040332" protId="MEDTR23530"/>\n' +
+  '        <gene id="11028861" protId="MEDTR12059"/>\n' +
+  '        <gene id="11025543" protId="MEDTR08741"/>\n' +
+  '        <gene id="11052361" protId="MEDTR35559"/>\n' +
+  '        <gene id="11052364" protId="MEDTR35562"/>\n' +
+  '        <gene id="11037291" protId="MEDTR20489"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pan troglodytes" NCBITaxId="9598">\n' +
+  '    <database name="Pan troglodytes from ENSEMBL v75" version="Ensembl 75; CHIMP2.1.4; 7-FEB-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7694462" protId="PANTR15391"/>\n' +
+  '        <gene id="7682436" protId="PANTR03365"/>\n' +
+  '        <gene id="7696938" protId="PANTR17867"/>\n' +
+  '        <gene id="7684928" protId="PANTR05857"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Brassica rapa subsp. pekinensis" NCBITaxId="51351">\n' +
+  '    <database name="Brassica rapa subsp. pekinensis from Ensembl Plants 36" version="Ensembl Plants 36; IVFCAASv1">\n' +
+  '      <genes>\n' +
+  '        <gene id="11192167" protId="BRARP07608"/>\n' +
+  '        <gene id="11197714" protId="BRARP13155"/>\n' +
+  '        <gene id="11216885" protId="BRARP32326"/>\n' +
+  '        <gene id="11194363" protId="BRARP09804"/>\n' +
+  '        <gene id="11189883" protId="BRARP05324"/>\n' +
+  '        <gene id="11206879" protId="BRARP22320"/>\n' +
+  '        <gene id="11208045" protId="BRARP23486"/>\n' +
+  '        <gene id="11223792" protId="BRARP39233"/>\n' +
+  '        <gene id="11197716" protId="BRARP13157"/>\n' +
+  '        <gene id="11220867" protId="BRARP36308"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Branchiostoma floridae" NCBITaxId="7739">\n' +
+  '    <database name="Branchiostoma floridae complete genome from JGI" version="Brafl1">\n' +
+  '      <genes>\n' +
+  '        <gene id="7058793" protId="BRAFL25322"/>\n' +
+  '        <gene id="7056313" protId="BRAFL22842"/>\n' +
+  '        <gene id="7052378" protId="BRAFL18907"/>\n' +
+  '        <gene id="7041673" protId="BRAFL08202"/>\n' +
+  '        <gene id="7040620" protId="BRAFL07149"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gadus morhua" NCBITaxId="8049">\n' +
+  '    <database name="Gadus morhua from ENSEMBL v70" version="Ensembl 70; gadMor1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7246166" protId="GADMO01548"/>\n' +
+  '        <gene id="7252762" protId="GADMO08144"/>\n' +
+  '        <gene id="7264994" protId="GADMO20376"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Anopheles gambiae" NCBITaxId="7165">\n' +
+  '    <database name="Anopheles gambiae full genome from ENSEMBL v46" version="Ensembl 46; AgamP3; 4-AUG-2007">\n' +
+  '      <genes>\n' +
+  '        <gene id="9119226" protId="ANOGA05592"/>\n' +
+  '        <gene id="9122428" protId="ANOGA08794"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tetraodon nigroviridis" NCBITaxId="99883">\n' +
+  '    <database name="Tetraodon nigroviridis from ENSEMBL v70" version="Ensembl 70; TETRAODON8; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7136752" protId="TETNG00443"/>\n' +
+  '        <gene id="7145801" protId="TETNG09492"/>\n' +
+  '        <gene id="7153296" protId="TETNG16987"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Theobroma cacao" NCBITaxId="3641">\n' +
+  '    <database name="Theobroma cacao from ENSEMBL plants v23" version="Ensembl Plants 23; GCA_000403535.1; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="11465659" protId="THECC23969"/>\n' +
+  '        <gene id="11452454" protId="THECC10764"/>\n' +
+  '        <gene id="11454248" protId="THECC12558"/>\n' +
+  '        <gene id="11460920" protId="THECC19230"/>\n' +
+  '        <gene id="11470768" protId="THECC29078"/>\n' +
+  '        <gene id="11452862" protId="THECC11172"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Amphimedon queenslandica" NCBITaxId="400682">\n' +
+  '    <database name="Amphimedon queenslandica from ENSEMBL Metazoa v12" version="Ensembl Metazoa 12; Aqu1; 18-DEC-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="9691773" protId="AMPQE13168"/>\n' +
+  '        <gene id="9700903" protId="AMPQE22298"/>\n' +
+  '        <gene id="9698997" protId="AMPQE20392"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Strongylocentrotus purpuratus" NCBITaxId="7668">\n' +
+  '    <database name="Strongylocentrotus purpuratus from ENSEMBL Metazoa v10" version="Ensembl Metazoa 10; Spur2.5; 2-JUL-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="8349164" protId="STRPU17050"/>\n' +
+  '        <gene id="8345991" protId="STRPU13877"/>\n' +
+  '        <gene id="8350856" protId="STRPU18742"/>\n' +
+  '        <gene id="8358181" protId="STRPU26067"/>\n' +
+  '        <gene id="8342419" protId="STRPU10305"/>\n' +
+  '        <gene id="8335813" protId="STRPU03699"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Capitella teleta" NCBITaxId="283909">\n' +
+  '    <database name="Capitella teleta from ENSEMBL metazoa v27" version="Ensembl Metazoa 27; GCA_000328365.1; 2-JUN-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9480612" protId="CAPTE17670"/>\n' +
+  '        <gene id="9480611" protId="CAPTE17669"/>\n' +
+  '        <gene id="9476944" protId="CAPTE14002"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Apis mellifera" NCBITaxId="7460">\n' +
+  '    <database name="Apis mellifera from ENSEMBL metazoa v13" version="Ensembl Metazoa 13; Amel_2.0; 27-FEB-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="9179364" protId="APIME09019"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Xiphophorus maculatus" NCBITaxId="8083">\n' +
+  '    <database name="Xiphophorus maculatus from ENSEMBL v69" version="Ensembl 69; Xipmac4.4.2; 4-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7221232" protId="XIPMA19241"/>\n' +
+  '        <gene id="7214493" protId="XIPMA12502"/>\n' +
+  '        <gene id="7207157" protId="XIPMA05166"/>\n' +
+  '        <gene id="7218024" protId="XIPMA16033"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus terreus (strain NIH 2624 / FGSC A1156)" NCBITaxId="341663">\n' +
+  '    <database name="Aspergillus terreus from JGI" version="JGI; Aspte1; 19-SEP-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6183044" protId="ASPTN02971"/>\n' +
+  '        <gene id="6187005" protId="ASPTN06932"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Taeniopygia guttata" NCBITaxId="59729">\n' +
+  '    <database name="Taeniopygia guttata from ENSEMBL v70" version="Ensembl 70; taeGut3.2.4; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8237471" protId="TAEGU08535"/>\n' +
+  '        <gene id="8229028" protId="TAEGU00092"/>\n' +
+  '        <gene id="8229597" protId="TAEGU00661"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Selaginella moellendorffii" NCBITaxId="88036">\n' +
+  '    <database name="Selaginella moellendorffii from ENSEMBL plants v21" version="Ensembl Plants 21; v1.0; 4-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="11613893" protId="SELML22112"/>\n' +
+  '        <gene id="11593852" protId="SELML02071"/>\n' +
+  '        <gene id="11597035" protId="SELML05254"/>\n' +
+  '        <gene id="11600082" protId="SELML08301"/>\n' +
+  '        <gene id="11598260" protId="SELML06479"/>\n' +
+  '        <gene id="11615053" protId="SELML23272"/>\n' +
+  '        <gene id="11617926" protId="SELML26145"/>\n' +
+  '        <gene id="11600515" protId="SELML08734"/>\n' +
+  '        <gene id="11610336" protId="SELML18555"/>\n' +
+  '        <gene id="11596179" protId="SELML04398"/>\n' +
+  '        <gene id="11617570" protId="SELML25789"/>\n' +
+  '        <gene id="11622454" protId="SELML30673"/>\n' +
+  '        <gene id="11612135" protId="SELML20354"/>\n' +
+  '        <gene id="11623837" protId="SELML32056"/>\n' +
+  '        <gene id="11597593" protId="SELML05812"/>\n' +
+  '        <gene id="11606214" protId="SELML14433"/>\n' +
+  '        <gene id="11598376" protId="SELML06595"/>\n' +
+  '        <gene id="11613895" protId="SELML22114"/>\n' +
+  '        <gene id="11603541" protId="SELML11760"/>\n' +
+  '        <gene id="11620502" protId="SELML28721"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Neurospora crassa (strain ATCC 24698 / 74-OR23-1A / CBS 708.71 / DSM 1257 / FGSC 987)" NCBITaxId="367110">\n' +
+  '    <database name="Neurospora crassa from ENSEMBL Fungi v4" version="Ensembl Fungi 4; EF 1; 17-FEB-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="6538397" protId="NEUCR02484"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tribolium castaneum" NCBITaxId="7070">\n' +
+  '    <database name="Tribolium castaneum from ENSEMBL Metazoa v12" version="Ensembl Metazoa 12; Tcas_3.0; 18-DEC-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="8775784" protId="TRICA08179"/>\n' +
+  '        <gene id="8768263" protId="TRICA00658"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Solanum tuberosum" NCBITaxId="4113">\n' +
+  '    <database name="Solanum tuberosum from ENSEMBL plants v21" version="Ensembl Plants 21; 3.0; 6-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10903123" protId="SOLTU22168"/>\n' +
+  '        <gene id="10886258" protId="SOLTU05303"/>\n' +
+  '        <gene id="10913304" protId="SOLTU32349"/>\n' +
+  '        <gene id="10893164" protId="SOLTU12209"/>\n' +
+  '        <gene id="10908968" protId="SOLTU28013"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Mnemiopsis leidyi" NCBITaxId="27923">\n' +
+  '    <database name="Mnemiopsis leidyi from ENSEMBL metazoa v27" version="Ensembl Metazoa 27; GCA_000226015.1; 2-JUN-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9663161" protId="MNELE12042"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila persimilis" NCBITaxId="7234">\n' +
+  '    <database name="Drosophila persimilis from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000005195.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8946280" protId="DROPE13314"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Colletotrichum graminicola" NCBITaxId="31870">\n' +
+  '    <database name="Colletotrichum graminicola from ENSEMBL fungi v28" version="Ensembl Fungi 28; GCA_000149035.1; 29-JUL-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="6391146" protId="COLGR02734"/>\n' +
+  '        <gene id="6397699" protId="COLGR09287"/>\n' +
+  '        <gene id="6396895" protId="COLGR08483"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Octopus bimaculoides" NCBITaxId="37653">\n' +
+  '    <database name="Octopus bimaculoides from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; PRJNA270931; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9573701" protId="OCTBM20412"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Xenopus tropicalis" NCBITaxId="8364">\n' +
+  '    <database name="Xenopus tropicalis from ENSEMBL v73" version="Ensembl 73; JGI_4.2; 23-AUG-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8294991" protId="XENTR12604"/>\n' +
+  '        <gene id="8285054" protId="XENTR02667"/>\n' +
+  '        <gene id="8292656" protId="XENTR10269"/>\n' +
+  '        <gene id="8290871" protId="XENTR08484"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ictidomys tridecemlineatus" NCBITaxId="43179">\n' +
+  '    <database name="Spermophilus tridecemlineatus from ENSEMBL v67" version="Ensembl 67; spetri2; 26-APR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7557360" protId="ICTTR13130"/>\n' +
+  '        <gene id="7555472" protId="ICTTR11242"/>\n' +
+  '        <gene id="7544396" protId="ICTTR00166"/>\n' +
+  '        <gene id="7558812" protId="ICTTR14582"/>\n' +
+  '        <gene id="7562658" protId="ICTTR18428"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sclerotinia sclerotiorum (strain ATCC 18683 / 1980 / Ss-1)" NCBITaxId="665079">\n' +
+  '    <database name="Sclerotinia sclerotiorum from JGI" version="JGI; Sclsc1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6386543" protId="SCLS112577"/>\n' +
+  '        <gene id="6378655" protId="SCLS104689"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Gibberella zeae" NCBITaxId="5518">\n' +
+  '    <database name="Gibberella zeae from JGI" version="JGI; Fusgr1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6486524" protId="GIBZA12889"/>\n' +
+  '        <gene id="6474511" protId="GIBZA00876"/>\n' +
+  '        <gene id="6486079" protId="GIBZA12444"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Cavia porcellus" NCBITaxId="10141">\n' +
+  '    <database name="Cavia porcellus from ENSEMBL v70" version="Ensembl 70; cavPor3; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7484731" protId="CAVPO08522"/>\n' +
+  '        <gene id="7486665" protId="CAVPO10456"/>\n' +
+  '        <gene id="7483861" protId="CAVPO07652"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Helobdella robusta" NCBITaxId="6412">\n' +
+  '    <database name="Helobdella robusta complete genome from JGI" version="Version 1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="9410599" protId="HELRO02482"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Naegleria gruberi" NCBITaxId="744533">\n' +
+  '    <database name="Naegleria gruberi (strain NEG-M) from JGI" version="Naegr1; 2-Mar-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="6053169" protId="NAEGR14356"/>\n' +
+  '        <gene id="6040834" protId="NAEGR02021"/>\n' +
+  '        <gene id="6047724" protId="NAEGR08911"/>\n' +
+  '        <gene id="6042203" protId="NAEGR03390"/>\n' +
+  '        <gene id="6048095" protId="NAEGR09282"/>\n' +
+  '        <gene id="6042791" protId="NAEGR03978"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Daphnia pulex" NCBITaxId="6669">\n' +
+  '    <database name="Daphnia pulex complete genome from JGI" version="Frozen gene catalog, version 1.1">\n' +
+  '      <genes>\n' +
+  '        <gene id="8674817" protId="DAPPU23176"/>\n' +
+  '        <gene id="8675461" protId="DAPPU23820"/>\n' +
+  '        <gene id="8658913" protId="DAPPU07272"/>\n' +
+  '        <gene id="8658914" protId="DAPPU07273"/>\n' +
+  '        <gene id="8658915" protId="DAPPU07274"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Serendipita indica (strain DSM 11827)" NCBITaxId="1109443">\n' +
+  '    <database name="Piriformospora indica from JGI" version="JGI; Pirin1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6819581" protId="SERID07469"/>\n' +
+  '        <gene id="6816466" protId="SERID04354"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aegilops tauschii" NCBITaxId="37682">\n' +
+  '    <database name="Aegilops tauschii from ENSEMBL plants v21" version="Ensembl Plants 21; GCA_000347335.1; 6-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10441019" protId="AEGTA27913"/>\n' +
+  '        <gene id="10437977" protId="AEGTA24871"/>\n' +
+  '        <gene id="10439477" protId="AEGTA26371"/>\n' +
+  '        <gene id="10431208" protId="AEGTA18102"/>\n' +
+  '        <gene id="10428668" protId="AEGTA15562"/>\n' +
+  '        <gene id="10424865" protId="AEGTA11759"/>\n' +
+  '        <gene id="10431053" protId="AEGTA17947"/>\n' +
+  '        <gene id="10430007" protId="AEGTA16901"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Culex quinquefasciatus" NCBITaxId="7176">\n' +
+  '    <database name="Culex quinquefasciatus from ENSEMBL Metazoa v6" version="Ensembl Metazoa v6; CpipJ1; 12-AUG-2010">\n' +
+  '      <genes>\n' +
+  '        <gene id="9164753" protId="CULQU13050"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza longistaminata" NCBITaxId="4528">\n' +
+  '    <database name="Oryza longistaminata from ENSEMBL plants v31" version="Ensembl Plants 31; O_longistaminata_v1.0; 1-APR-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="10156145" protId="ORYLO11956"/>\n' +
+  '        <gene id="10161159" protId="ORYLO16970"/>\n' +
+  '        <gene id="10166645" protId="ORYLO22456"/>\n' +
+  '        <gene id="10168433" protId="ORYLO24244"/>\n' +
+  '        <gene id="10165346" protId="ORYLO21157"/>\n' +
+  '        <gene id="10166923" protId="ORYLO22734"/>\n' +
+  '        <gene id="10158295" protId="ORYLO14106"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tetrahymena thermophila (strain SB210)" NCBITaxId="312017">\n' +
+  '    <database name="Tetrahymena thermophila from ENSEMBL protists v31" version="Ensembl Protists 31; JCVI-TTA1-2; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="5782938" protId="TETTS11607"/>\n' +
+  '        <gene id="5782942" protId="TETTS11611"/>\n' +
+  '        <gene id="5778396" protId="TETTS07065"/>\n' +
+  '        <gene id="5782940" protId="TETTS11609"/>\n' +
+  '        <gene id="5782943" protId="TETTS11612"/>\n' +
+  '        <gene id="5782939" protId="TETTS11608"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Rattus norvegicus" NCBITaxId="10116">\n' +
+  '    <database name="Rattus norvegicus from ENSEMBL v83" version="Ensembl 83; Rnor_6.0; 28-NOV-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="7543705" protId="RATNO21837"/>\n' +
+  '        <gene id="7523267" protId="RATNO01399"/>\n' +
+  '        <gene id="7522106" protId="RATNO00238"/>\n' +
+  '        <gene id="7543281" protId="RATNO21413"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Cryphonectria parasitica" NCBITaxId="5116">\n' +
+  '    <database name="Cryphonectria parasitica from JGI" version="JGI; Crypa2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6513335" protId="CRYPA10709"/>\n' +
+  '        <gene id="6508637" protId="CRYPA06011"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Laccaria bicolor" NCBITaxId="29883">\n' +
+  '    <database name="Laccaria bicolor complete genome from JGI" version="Version 1.0 (May 22, 2006)">\n' +
+  '      <genes>\n' +
+  '        <gene id="6868982" protId="LACBI02759"/>\n' +
+  '        <gene id="6867443" protId="LACBI01220"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dictyostelium discoideum" NCBITaxId="44689">\n' +
+  '    <database name="Dictyostelium discoideum strain AX4 from dictyBase" version="release-2-12; 08-30-2009 01:33">\n' +
+  '      <genes>\n' +
+  '        <gene id="5889714" protId="DICDI10473"/>\n' +
+  '        <gene id="5888489" protId="DICDI09248"/>\n' +
+  '        <gene id="5890419" protId="DICDI11178"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Arabidopsis lyrata" NCBITaxId="59689">\n' +
+  '    <database name="Arabidopsis lyrata subsp. lyrata from Ensembl 37" version="Ensembl 37; v.1.0">\n' +
+  '      <genes>\n' +
+  '        <gene id="11412157" protId="ARALY30623"/>\n' +
+  '        <gene id="11411063" protId="ARALY29529"/>\n' +
+  '        <gene id="11387012" protId="ARALY05478"/>\n' +
+  '        <gene id="11410532" protId="ARALY28998"/>\n' +
+  '        <gene id="11407126" protId="ARALY25592"/>\n' +
+  '        <gene id="11401956" protId="ARALY20422"/>\n' +
+  '        <gene id="11382406" protId="ARALY00872"/>\n' +
+  '        <gene id="11413260" protId="ARALY31726"/>\n' +
+  '        <gene id="11410459" protId="ARALY28925"/>\n' +
+  '        <gene id="11399180" protId="ARALY17646"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Zymoseptoria tritici" NCBITaxId="1047171">\n' +
+  '    <database name="Zymoseptoria tritici from ENSEMBL fungi v28" version="Ensembl Fungi 28; MG2; 29-JUL-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="6282514" protId="ZYMTR10086"/>\n' +
+  '        <gene id="6273019" protId="ZYMTR00591"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Colletotrichum sublineola" NCBITaxId="1173701">\n' +
+  '    <database name="Colletotrichum sublineola from ENSEMBL fungi v28" version="Ensembl Fungi 28; GCA_000696135.1; 6-JUN-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="6403855" protId="COLSU03424"/>\n' +
+  '        <gene id="6404263" protId="COLSU03832"/>\n' +
+  '        <gene id="6408974" protId="COLSU08543"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Guillardia theta" NCBITaxId="905079">\n' +
+  '    <database name="Guillardia theta from ENSEMBL protists v21" version="Ensembl Protists 21; GCA_000315625.1; 2-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="5928082" protId="GUITH11236"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Solanum lycopersicum" NCBITaxId="4081">\n' +
+  '    <database name="Solanum lycopersicum from ENSEMBL plants v27" version="Ensembl Plants 27; GCA_000188115.2; 27-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="10873122" protId="SOLLC25869"/>\n' +
+  '        <gene id="10865075" protId="SOLLC17822"/>\n' +
+  '        <gene id="10878286" protId="SOLLC31033"/>\n' +
+  '        <gene id="10872541" protId="SOLLC25288"/>\n' +
+  '        <gene id="10856386" protId="SOLLC09133"/>\n' +
+  '        <gene id="10850353" protId="SOLLC03100"/>\n' +
+  '        <gene id="10869646" protId="SOLLC22393"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tupaia belangeri" NCBITaxId="37347">\n' +
+  '    <database name="Tupaia belangeri from ENSEMBL v70" version="Ensembl 70; TREESHREW; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7815773" protId="TUPBE07339"/>\n' +
+  '        <gene id="7814808" protId="TUPBE06374"/>\n' +
+  '        <gene id="7816060" protId="TUPBE07626"/>\n' +
+  '        <gene id="7818841" protId="TUPBE10407"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ficedula albicollis" NCBITaxId="59894">\n' +
+  '    <database name="Ficedula albicollis from ENSEMBL v73" version="Ensembl 73; FicAlb_1.4; 23-AUG-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="8220303" protId="FICAL06750"/>\n' +
+  '        <gene id="8213705" protId="FICAL00152"/>\n' +
+  '        <gene id="8220149" protId="FICAL06596"/>\n' +
+  '        <gene id="8223185" protId="FICAL09632"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Musa acuminata subsp. malaccensis" NCBITaxId="214687">\n' +
+  '    <database name="Musa acuminata from ENSEMBL plants v21" version="Ensembl Plants 21; MA1; 6-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10831292" protId="MUSAM20478"/>\n' +
+  '        <gene id="10832967" protId="MUSAM22153"/>\n' +
+  '        <gene id="10832516" protId="MUSAM21702"/>\n' +
+  '        <gene id="10814018" protId="MUSAM03204"/>\n' +
+  '        <gene id="10834518" protId="MUSAM23704"/>\n' +
+  '        <gene id="10814868" protId="MUSAM04054"/>\n' +
+  '        <gene id="10831064" protId="MUSAM20250"/>\n' +
+  '        <gene id="10841780" protId="MUSAM30966"/>\n' +
+  '        <gene id="10815363" protId="MUSAM04549"/>\n' +
+  '        <gene id="10821586" protId="MUSAM10772"/>\n' +
+  '        <gene id="10841945" protId="MUSAM31131"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Canis lupus familiaris" NCBITaxId="9615">\n' +
+  '    <database name="Canis familiaris from ENSEMBL v70" version="Ensembl 70; CanFam3.1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7843485" protId="CANLF19678"/>\n' +
+  '        <gene id="7836453" protId="CANLF12646"/>\n' +
+  '        <gene id="7843772" protId="CANLF19965"/>\n' +
+  '        <gene id="7831998" protId="CANLF08191"/>\n' +
+  '        <gene id="7824038" protId="CANLF00231"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Fomitopsis pinicola (strain FP-58527)" NCBITaxId="743788">\n' +
+  '    <database name="Fomitopsis pinicola from JGI" version="JGI; Fompi3; 05-JUL-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6740248" protId="FOMPI02192"/>\n' +
+  '        <gene id="6747911" protId="FOMPI09855"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Auricularia subglabra (strain TFB-10046 / SS5)" NCBITaxId="717982">\n' +
+  '    <database name="Auricularia delicata from JGI" version="JGI; Aurde1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6663420" protId="AURST19117"/>\n' +
+  '        <gene id="6644939" protId="AURST00636"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Macaca mulatta" NCBITaxId="9544">\n' +
+  '    <database name="Macaca mulatta from ENSEMBL v70" version="Ensembl 70; MMUL_1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7602269" protId="MACMU19828"/>\n' +
+  '        <gene id="7605835" protId="MACMU23394"/>\n' +
+  '        <gene id="7590180" protId="MACMU07739"/>\n' +
+  '        <gene id="7599553" protId="MACMU17112"/>\n' +
+  '        <gene id="7605438" protId="MACMU22997"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Leptosphaeria maculans (strain JN3 / isolate v23.1.3 / race Av1-4-5-6-7-8)" NCBITaxId="985895">\n' +
+  '    <database name="Leptosphaeria maculans from JGI" version="JGI; Lepmu1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6297688" protId="LEPMJ03538"/>\n' +
+  '        <gene id="6297333" protId="LEPMJ03183"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Hypocrea jecorina" NCBITaxId="51453">\n' +
+  '    <database name="Hypocrea jecorina from JGI" version="JGI; Trire2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6441357" protId="HYPJE05847"/>\n' +
+  '        <gene id="6443461" protId="HYPJE07951"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Salpingoeca rosetta (strain ATCC 50818 / BSB-021)" NCBITaxId="946362">\n' +
+  '    <database name="Salpingoeca rosetta from Ensembl Protists 36" version="Ensembl Protists 36; Proterospongia_sp_ATCC50818">\n' +
+  '      <genes>\n' +
+  '        <gene id="6068007" protId="SALR504461"/>\n' +
+  '        <gene id="6071012" protId="SALR507466"/>\n' +
+  '        <gene id="6069674" protId="SALR506128"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Arabidopsis thaliana" NCBITaxId="3702">\n' +
+  '    <database name="Arabidopsis thaliana from ENSEMBL plants v20" version="Ensembl Plants 20; TAIR10; 2-SEP-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="11426373" protId="ARATH12172"/>\n' +
+  '        <gene id="11435437" protId="ARATH21236"/>\n' +
+  '        <gene id="11432442" protId="ARATH18241"/>\n' +
+  '        <gene id="11439915" protId="ARATH25714"/>\n' +
+  '        <gene id="11432783" protId="ARATH18582"/>\n' +
+  '        <gene id="11416873" protId="ARATH02672"/>\n' +
+  '        <gene id="11428936" protId="ARATH14735"/>\n' +
+  '        <gene id="11433755" protId="ARATH19554"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza nivara" NCBITaxId="4536">\n' +
+  '    <database name="Oryza nivara from ENSEMBL plants v23" version="Ensembl Plants 23; AWHD00000000; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="10177629" protId="ORYNI03509"/>\n' +
+  '        <gene id="10200785" protId="ORYNI26665"/>\n' +
+  '        <gene id="10183302" protId="ORYNI09182"/>\n' +
+  '        <gene id="10178356" protId="ORYNI04236"/>\n' +
+  '        <gene id="10184849" protId="ORYNI10729"/>\n' +
+  '        <gene id="10209220" protId="ORYNI35100"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Dipodomys ordii" NCBITaxId="10020">\n' +
+  '    <database name="Dipodomys ordii from ENSEMBL v70" version="Ensembl 70; dipOrd1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7467743" protId="DIPOR07252"/>\n' +
+  '        <gene id="7470957" protId="DIPOR10466"/>\n' +
+  '        <gene id="7474889" protId="DIPOR14398"/>\n' +
+  '        <gene id="7469861" protId="DIPOR09370"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryzias latipes" NCBITaxId="8090">\n' +
+  '    <database name="Oryzias latipes from ENSEMBL v70" version="Ensembl 70; MEDAKA1; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7171539" protId="ORYLA15210"/>\n' +
+  '        <gene id="7159915" protId="ORYLA03586"/>\n' +
+  '        <gene id="7157317" protId="ORYLA00988"/>\n' +
+  '        <gene id="7164883" protId="ORYLA08554"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Wolfiporia cocos (strain MD-104)" NCBITaxId="742152">\n' +
+  '    <database name="Wolfiporia cocos from JGI" version="JGI; Wolco1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6736750" protId="WOLCO11420"/>\n' +
+  '        <gene id="6726139" protId="WOLCO00809"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Cochliobolus lunatus" NCBITaxId="5503">\n' +
+  '    <database name="Cochliobolus lunatus from JGI" version="JGI; Coclu2; 21-MAY-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6342805" protId="COCLU03725"/>\n' +
+  '        <gene id="6349929" protId="COCLU10849"/>\n' +
+  '        <gene id="6343047" protId="COCLU03967"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Schizophyllum commune" NCBITaxId="5334">\n' +
+  '    <database name="Schizophyllum commune from JGI" version="JGI; Schco1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6864981" protId="SCHCO11870"/>\n' +
+  '        <gene id="6859791" protId="SCHCO06680"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Mus musculus" NCBITaxId="10090">\n' +
+  '    <database name="Mus musculus from ENSEMBL v86" version="Ensembl 86; GRCm38; 13-SEP-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="7520633" protId="MOUSE25484"/>\n' +
+  '        <gene id="7504589" protId="MOUSE09440"/>\n' +
+  '        <gene id="7516661" protId="MOUSE21512"/>\n' +
+  '        <gene id="7521316" protId="MOUSE26167"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ailuropoda melanoleuca" NCBITaxId="9646">\n' +
+  '    <database name="Ailuropoda melanoleuca from ENSEMBL v70" version="Ensembl 70; ailMel1; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7868951" protId="AILME04629"/>\n' +
+  '        <gene id="7868248" protId="AILME03926"/>\n' +
+  '        <gene id="7875688" protId="AILME11366"/>\n' +
+  '        <gene id="7867492" protId="AILME03170"/>\n' +
+  '        <gene id="7882921" protId="AILME18599"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila biarmipes" NCBITaxId="125945">\n' +
+  '    <database name="Drosophila biarmipes from modENCODE" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="8832593" protId="DROBM09807"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Lotus japonicus" NCBITaxId="34305">\n' +
+  '    <database name="Lotus japonicus from modENCODE" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="10960893" protId="LOTJA38142"/>\n' +
+  '        <gene id="10953609" protId="LOTJA30858"/>\n' +
+  '        <gene id="10955259" protId="LOTJA32508"/>\n' +
+  '        <gene id="10957685" protId="LOTJA34934"/>\n' +
+  '        <gene id="10957686" protId="LOTJA34935"/>\n' +
+  '        <gene id="10937640" protId="LOTJA14889"/>\n' +
+  '        <gene id="10955428" protId="LOTJA32677"/>\n' +
+  '        <gene id="10945516" protId="LOTJA22765"/>\n' +
+  '        <gene id="10940163" protId="LOTJA17412"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus oryzae (strain ATCC 42149 / RIB 40)" NCBITaxId="510516">\n' +
+  '    <database name="Aspergillus oryzae from JGI" version="JGI; Aspor1; 08-AUG-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6171165" protId="ASPOR03100"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Verticillium dahliae" NCBITaxId="27337">\n' +
+  '    <database name="Verticillium dahliae from JGI" version="JGI; Verda1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6419396" protId="VERDA06272"/>\n' +
+  '        <gene id="6415451" protId="VERDA02327"/>\n' +
+  '        <gene id="6413156" protId="VERDA00032"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tarsius syrichta" NCBITaxId="1868482">\n' +
+  '    <database name="Tarsius syrichta from ENSEMBL v70" version="Ensembl 70; tarSyr1; 12-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7768559" protId="TARSY09417"/>\n' +
+  '        <gene id="7770397" protId="TARSY11255"/>\n' +
+  '        <gene id="7769026" protId="TARSY09884"/>\n' +
+  '        <gene id="7770490" protId="TARSY11348"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza punctata" NCBITaxId="4537">\n' +
+  '    <database name="Oryza punctata from ENSEMBL plants v23" version="Ensembl Plants 23; AVCL00000000; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="10215371" protId="ORYPU03504"/>\n' +
+  '        <gene id="10214828" protId="ORYPU02961"/>\n' +
+  '        <gene id="10213360" protId="ORYPU01493"/>\n' +
+  '        <gene id="10234095" protId="ORYPU22228"/>\n' +
+  '        <gene id="10219480" protId="ORYPU07613"/>\n' +
+  '        <gene id="10219483" protId="ORYPU07616"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila rhopaloa" NCBITaxId="1041015">\n' +
+  '    <database name="Drosophila rhopaloa from modENCODE" version="">\n' +
+  '      <genes>\n' +
+  '        <gene id="8971400" protId="DRORH05849"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Vicugna pacos" NCBITaxId="30538">\n' +
+  '    <database name="Vicugna pacos from ENSEMBL v75" version="Ensembl 75; vicPac1; 7-FEB-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7989171" protId="VICPA05338"/>\n' +
+  '        <gene id="7993588" protId="VICPA09755"/>\n' +
+  '        <gene id="7987850" protId="VICPA04017"/>\n' +
+  '        <gene id="7988353" protId="VICPA04520"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Bombus impatiens" NCBITaxId="132113">\n' +
+  '    <database name="Bombus impatiens from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; GCA_000188095.2; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9183602" protId="BOMIM02879"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Manihot esculenta" NCBITaxId="3983">\n' +
+  '    <database name="Manihot esculenta from Phytozome v7" version="v4.1">\n' +
+  '      <genes>\n' +
+  '        <gene id="11078737" protId="MANES18979"/>\n' +
+  '        <gene id="11090098" protId="MANES30340"/>\n' +
+  '        <gene id="11066262" protId="MANES06504"/>\n' +
+  '        <gene id="11070398" protId="MANES10640"/>\n' +
+  '        <gene id="11079051" protId="MANES19293"/>\n' +
+  '        <gene id="11067050" protId="MANES07292"/>\n' +
+  '        <gene id="11063288" protId="MANES03530"/>\n' +
+  '        <gene id="11064826" protId="MANES05068"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Puccinia graminis" NCBITaxId="5297">\n' +
+  '    <database name="Puccinia graminis from JGI" version="JGI; Pucgr1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6938629" protId="PUCGR05874"/>\n' +
+  '        <gene id="6941008" protId="PUCGR08253"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Myotis lucifugus" NCBITaxId="59463">\n' +
+  '    <database name="Myotis lucifugus from ENSEMBL v80" version="Ensembl 80; Myoluc2.0; 15-MAY-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="8020730" protId="MYOLU08217"/>\n' +
+  '        <gene id="8014793" protId="MYOLU02280"/>\n' +
+  '        <gene id="8028276" protId="MYOLU15763"/>\n' +
+  '        <gene id="8013805" protId="MYOLU01292"/>\n' +
+  '        <gene id="8020067" protId="MYOLU07554"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Setaria italica" NCBITaxId="4555">\n' +
+  '    <database name="Setaria italica from ENSEMBL plants v21" version="Ensembl Plants 21; JGIv2.0; 3-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10744982" protId="SETIT06231"/>\n' +
+  '        <gene id="10749047" protId="SETIT10296"/>\n' +
+  '        <gene id="10756236" protId="SETIT17485"/>\n' +
+  '        <gene id="10766927" protId="SETIT28176"/>\n' +
+  '        <gene id="10757732" protId="SETIT18981"/>\n' +
+  '        <gene id="10760158" protId="SETIT21407"/>\n' +
+  '        <gene id="10758392" protId="SETIT19641"/>\n' +
+  '        <gene id="10766795" protId="SETIT28044"/>\n' +
+  '        <gene id="10756429" protId="SETIT17678"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Ectocarpus siliculosus" NCBITaxId="2880">\n' +
+  '    <database name="Ectocarpus siliculosus strain Ec 32, whole genome shotgun sequence assembly, chromosome LG01" version="17-SEP-2015 (Rel. 126, Last updated, Version 3)">\n' +
+  '      <genes>\n' +
+  '        <gene id="9933764" protId="ECTSI01569"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Meleagris gallopavo" NCBITaxId="9103">\n' +
+  '    <database name="Meleagris gallopavo from ENSEMBL v70" version="Ensembl 70; UMD2; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="8189367" protId="MELGA05945"/>\n' +
+  '        <gene id="8184782" protId="MELGA01360"/>\n' +
+  '        <gene id="8196382" protId="MELGA12960"/>\n' +
+  '        <gene id="8186689" protId="MELGA03267"/>\n' +
+  '        <gene id="8185363" protId="MELGA01941"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Pristionchus pacificus" NCBITaxId="54126">\n' +
+  '    <database name="Pristionchus pacificus full genome from Wormbase 196" version="Wormbase WS196; 31-Oct-2008">\n' +
+  '      <genes>\n' +
+  '        <gene id="8394793" protId="PRIPA24393"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Petromyzon marinus" NCBITaxId="7757">\n' +
+  '    <database name="Petromyzon marinus from ENSEMBL v82" version="Ensembl 82; Pmarinus_7.0; 18-SEP-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="7069767" protId="PETMA07832"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sarcophilus harrisii" NCBITaxId="9305">\n' +
+  '    <database name="Sarcophilus harrisii from ENSEMBL" version="Ensembl 64; DEVIL7.0; 3-SEP-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="8116312" protId="SARHA00086"/>\n' +
+  '        <gene id="8123971" protId="SARHA07745"/>\n' +
+  '        <gene id="8120762" protId="SARHA04536"/>\n' +
+  '        <gene id="8127426" protId="SARHA11200"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Danio rerio" NCBITaxId="7955">\n' +
+  '    <database name="Danio rerio from Ensembl 90" version="Ensembl 90; GRCz10">\n' +
+  '      <genes>\n' +
+  '        <gene id="7313395" protId="DANRE25219"/>\n' +
+  '        <gene id="7290714" protId="DANRE02538"/>\n' +
+  '        <gene id="7295341" protId="DANRE07165"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Sarcoptes scabiei" NCBITaxId="52283">\n' +
+  '    <database name="Sarcoptes scabiei from ENSEMBL metazoa v31" version="Ensembl Metazoa 31; SscaA1; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="8592987" protId="SARSC05096"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tremella mesenterica" NCBITaxId="5217">\n' +
+  '    <database name="Tremella mesenterica from JGI" version="JGI; Treme1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6916358" protId="TREME03901"/>\n' +
+  '        <gene id="6918105" protId="TREME05648"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila erecta" NCBITaxId="7220">\n' +
+  '    <database name="Drosophila erecta from ENSEMBL metazoa v25" version="Ensembl Metazoa 25; GCA_000005135.1; 18-DEC-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="8861216" protId="DROER07739"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Astyanax mexicanus" NCBITaxId="7994">\n' +
+  '    <database name="Astyanax mexicanus from ENSEMBL v74" version="Ensembl 74; AstMex102; 27-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="7267311" protId="ASTMX02214"/>\n' +
+  '        <gene id="7276949" protId="ASTMX11852"/>\n' +
+  '        <gene id="7269617" protId="ASTMX04520"/>\n' +
+  '        <gene id="7270952" protId="ASTMX05855"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Echinops telfairi" NCBITaxId="9371">\n' +
+  '    <database name="Echinops telfairi from ENSEMBL v70" version="Ensembl 70; TENREC; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7424946" protId="ECHTE16189"/>\n' +
+  '        <gene id="7418526" protId="ECHTE09769"/>\n' +
+  '        <gene id="7423188" protId="ECHTE14431"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Drosophila mojavensis" NCBITaxId="7230">\n' +
+  '    <database name="Drosophila mojavensis from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; dmoj_caf1; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="9090940" protId="DROMO05881"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aspergillus clavatus (strain ATCC 1007 / CBS 513.65 / DSM 816 / NCTC 3887 / NRRL 1)" NCBITaxId="344612">\n' +
+  '    <database name="Aspergillus clavatus from ENSEMBL fungi v16" version="Ensembl Fungi 16; CADRE; 19-OCT-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6129854" protId="ASPCL04855"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Chlorocebus sabaeus" NCBITaxId="60711">\n' +
+  '    <database name="Chlorocebus sabaeus from ENSEMBL v77" version="Ensembl 77; ChlSab1.1; 26-SEP-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="7575792" protId="CHLSB12523"/>\n' +
+  '        <gene id="7582310" protId="CHLSB19041"/>\n' +
+  '        <gene id="7581918" protId="CHLSB18649"/>\n' +
+  '        <gene id="7564147" protId="CHLSB00878"/>\n' +
+  '        <gene id="7567138" protId="CHLSB03869"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Felis catus" NCBITaxId="9685">\n' +
+  '    <database name="Felis catus from ENSEMBL v70" version="Ensembl 70; Felis_catus_6.2; 11-DEC-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7890472" protId="FELCA06334"/>\n' +
+  '        <gene id="7902850" protId="FELCA18712"/>\n' +
+  '        <gene id="7903134" protId="FELCA18996"/>\n' +
+  '        <gene id="7890146" protId="FELCA06008"/>\n' +
+  '        <gene id="7895618" protId="FELCA11480"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oryza glaberrima" NCBITaxId="4538">\n' +
+  '    <database name="Oryza glaberrima from ENSEMBL plants v21" version="Ensembl Plants 21; AGI1.1; 6-DEC-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="10132798" protId="ORYGL20214"/>\n' +
+  '        <gene id="10114957" protId="ORYGL02373"/>\n' +
+  '        <gene id="10119212" protId="ORYGL06628"/>\n' +
+  '        <gene id="10115485" protId="ORYGL02901"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Tuber melanosporum (strain Mel28)" NCBITaxId="656061">\n' +
+  '    <database name="Tuber melanosporum from JGI" version="JGI; Tubme1; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6109271" protId="TUBMM02584"/>\n' +
+  '        <gene id="6107556" protId="TUBMM00869"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Crassostrea gigas" NCBITaxId="29159">\n' +
+  '    <database name="Crassostrea gigas from ENSEMBL metazoa v21" version="Ensembl Metazoa 21; GCA_000297895.1; 29-NOV-2013">\n' +
+  '      <genes>\n' +
+  '        <gene id="9531614" protId="CRAGI04174"/>\n' +
+  '        <gene id="9550270" protId="CRAGI22830"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Thielavia heterothallica" NCBITaxId="78579">\n' +
+  '    <database name="Thielavia heterothallica from JGI" version="JGI; Spoth2; 07-MAR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6533767" protId="THIHE06941"/>\n' +
+  '        <gene id="6527080" protId="THIHE00254"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Saprolegnia parasitica (strain CBS 223.65)" NCBITaxId="695850">\n' +
+  '    <database name="Saprolegnia parasitica CBS 223.65 from ENSEMBL protists v31" version="Ensembl Protists 31; ASM15154v2; 18-FEB-2016">\n' +
+  '      <genes>\n' +
+  '        <gene id="9931612" protId="SAPPC19270"/>\n' +
+  '        <gene id="9931609" protId="SAPPC19267"/>\n' +
+  '        <gene id="9913688" protId="SAPPC01346"/>\n' +
+  '        <gene id="9931442" protId="SAPPC19100"/>\n' +
+  '        <gene id="9913292" protId="SAPPC00950"/>\n' +
+  '        <gene id="9929691" protId="SAPPC17349"/>\n' +
+  '        <gene id="9914608" protId="SAPPC02266"/>\n' +
+  '        <gene id="9924846" protId="SAPPC12504"/>\n' +
+  '        <gene id="9927037" protId="SAPPC14695"/>\n' +
+  '        <gene id="9920329" protId="SAPPC07987"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Prunus persica" NCBITaxId="3760">\n' +
+  '    <database name="Prunus persica from ENSEMBL plants v23" version="Ensembl Plants 23; GCA_000346465.1; 19-JUL-2014">\n' +
+  '      <genes>\n' +
+  '        <gene id="11135497" protId="PRUPE01705"/>\n' +
+  '        <gene id="11149307" protId="PRUPE15515"/>\n' +
+  '        <gene id="11157553" protId="PRUPE23761"/>\n' +
+  '        <gene id="11135794" protId="PRUPE02002"/>\n' +
+  '        <gene id="11151654" protId="PRUPE17862"/>\n' +
+  '        <gene id="11136420" protId="PRUPE02628"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aedes aegypti" NCBITaxId="7159">\n' +
+  '    <database name="Aedes aegypti full genome from ENSEMBL v42" version="AaegL1; Ensembl v42; 26-NOV-2006">\n' +
+  '      <genes>\n' +
+  '        <gene id="9141320" protId="AEDAE04746"/>\n' +
+  '        <gene id="9146746" protId="AEDAE10172"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Vitis vinifera" NCBITaxId="29760">\n' +
+  '    <database name="Vitis vinifera from ENSEMBL Plants v8" version="Ensembl Plants v9; IGGP_12x; 14-APR-2011">\n' +
+  '      <genes>\n' +
+  '        <gene id="11561474" protId="VITVI23171"/>\n' +
+  '        <gene id="11557753" protId="VITVI19450"/>\n' +
+  '        <gene id="11548969" protId="VITVI10666"/>\n' +
+  '        <gene id="11557157" protId="VITVI18854"/>\n' +
+  '        <gene id="11546685" protId="VITVI08382"/>\n' +
+  '        <gene id="11557754" protId="VITVI19451"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Spizellomyces punctatus" NCBITaxId="109760">\n' +
+  '    <database name="Spizellomyces punctatus from Broad Institute" version="BroadInstitute; v1; 01-03-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6093285" protId="SPIPN00827"/>\n' +
+  '        <gene id="6099660" protId="SPIPN07202"/>\n' +
+  '        <gene id="6098594" protId="SPIPN06136"/>\n' +
+  '        <gene id="6096847" protId="SPIPN04389"/>\n' +
+  '        <gene id="6099636" protId="SPIPN07178"/>\n' +
+  '        <gene id="6100038" protId="SPIPN07580"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Populus trichocarpa" NCBITaxId="3694">\n' +
+  '    <database name="Populus trichocarpa from ENSEMBL plants v15" version="Ensembl Plants 15; JGI2.0; 27-JUL-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="11104729" protId="POPTR12234"/>\n' +
+  '        <gene id="11130324" protId="POPTR37829"/>\n' +
+  '        <gene id="11127254" protId="POPTR34759"/>\n' +
+  '        <gene id="11130056" protId="POPTR37561"/>\n' +
+  '        <gene id="11123812" protId="POPTR31317"/>\n' +
+  '        <gene id="11115448" protId="POPTR22953"/>\n' +
+  '        <gene id="11100359" protId="POPTR07864"/>\n' +
+  '        <gene id="11115196" protId="POPTR22701"/>\n' +
+  '        <gene id="11097550" protId="POPTR05055"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Anopheles darlingi" NCBITaxId="43151">\n' +
+  '    <database name="Anopheles darlingi from ENSEMBL metazoa v27" version="Ensembl Metazoa 27; AdarC3; 2-JUN-2015">\n' +
+  '      <genes>\n' +
+  '        <gene id="9129749" protId="ANODA03616"/>\n' +
+  '        <gene id="9133724" protId="ANODA07591"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Aureobasidium pullulans" NCBITaxId="5580">\n' +
+  '    <database name="Aureobasidium pullulans from JGI" version="JGI; Aurpu_var_sub1; 15-MAY-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="6288474" protId="AURPU05132"/>\n' +
+  '        <gene id="6293913" protId="AURPU10571"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <species name="Oreochromis niloticus" NCBITaxId="8128">\n' +
+  '    <database name="Oreochromis niloticus from ENSEMBL v67" version="Ensembl 67; Orenil1.0; 26-APR-2012">\n' +
+  '      <genes>\n' +
+  '        <gene id="7233571" protId="ORENI11210"/>\n' +
+  '        <gene id="7240812" protId="ORENI18451"/>\n' +
+  '        <gene id="7224251" protId="ORENI01890"/>\n' +
+  '        <gene id="7232998" protId="ORENI10637"/>\n' +
+  '      </genes>\n' +
+  '    </database>\n' +
+  '  </species>\n' +
+  '  <groups>\n' +
+  '    <orthologGroup id="601272">\n' +
+  '      <property name="TaxRange" value="LUCA"/>\n' +
+  '      <paralogGroup>\n' +
+  '        <geneRef id="10760158"/>\n' +
+  '        <orthologGroup>\n' +
+  '          <property name="TaxRange" value="Eukaryota"/>\n' +
+  '          <paralogGroup>\n' +
+  '            <geneRef id="6042203"/>\n' +
+  '            <geneRef id="6053169"/>\n' +
+  '            <geneRef id="6047724"/>\n' +
+  '            <geneRef id="6048095"/>\n' +
+  '            <geneRef id="6040834"/>\n' +
+  '            <geneRef id="6042791"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Streptophyta"/>\n' +
+  '              <geneRef id="10034829"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                <geneRef id="10801934"/>\n' +
+  '                <geneRef id="10832516"/>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Magnoliophyta"/>\n' +
+  '              <geneRef id="11576518"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Mesangiospermae"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="rosids"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="fabids"/>\n' +
+  '                    <geneRef id="11136420"/>\n' +
+  '                    <geneRef id="11063288"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="10970379"/>\n' +
+  '                        <geneRef id="10972216"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <geneRef id="10953609"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                    <paralogGroup>\n' +
+  '                      <geneRef id="11534380"/>\n' +
+  '                      <geneRef id="11527973"/>\n' +
+  '                    </paralogGroup>\n' +
+  '                    <geneRef id="11452454"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="commelinids"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                    <geneRef id="10798369"/>\n' +
+  '                    <geneRef id="10841945"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Poaceae"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="10620333"/>\n' +
+  '                        <geneRef id="10654700"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                        <geneRef id="10659720"/>\n' +
+  '                        <geneRef id="10697414"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Triticeae"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Triticum"/>\n' +
+  '                          <geneRef id="10574484"/>\n' +
+  '                          <geneRef id="10600466"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Triticinae"/>\n' +
+  '                          <geneRef id="10431053"/>\n' +
+  '                          <geneRef id="10508503"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <geneRef id="10463383"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <geneRef id="10396270"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Viridiplantae"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <geneRef id="9968246"/>\n' +
+  '                <geneRef id="9968880"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <geneRef id="10038263"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Poaceae"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="BOP clade"/>\n' +
+  '                  <geneRef id="10402431"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Oryza"/>\n' +
+  '                    <geneRef id="10111024"/>\n' +
+  '                    <geneRef id="10166645"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Triticum"/>\n' +
+  '                  <geneRef id="10566973"/>\n' +
+  '                  <geneRef id="10599200"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </paralogGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                <geneRef id="10625406"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                  <geneRef id="10744982"/>\n' +
+  '                  <geneRef id="10729394"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="10635498"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Solanum"/>\n' +
+  '              <geneRef id="10869646"/>\n' +
+  '              <geneRef id="10908968"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Streptophyta"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Embryophyta"/>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="10076891"/>\n' +
+  '                    <geneRef id="10055354"/>\n' +
+  '                    <geneRef id="10073775"/>\n' +
+  '                    <geneRef id="10078761"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="11622454"/>\n' +
+  '                    <geneRef id="11613895"/>\n' +
+  '                    <geneRef id="11600082"/>\n' +
+  '                    <geneRef id="11597035"/>\n' +
+  '                    <geneRef id="11613893"/>\n' +
+  '                    <geneRef id="11615053"/>\n' +
+  '                    <geneRef id="11620502"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Tracheophyta"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="11596179"/>\n' +
+  '                        <geneRef id="11617926"/>\n' +
+  '                        <geneRef id="11612135"/>\n' +
+  '                        <geneRef id="11610336"/>\n' +
+  '                        <geneRef id="11593852"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Magnoliophyta"/>\n' +
+  '                        <geneRef id="11588912"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Mesangiospermae"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="11516783"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Pentapetalae"/>\n' +
+  '                              <geneRef id="10878286"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="rosids"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="malvids"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                                      <paralogGroup>\n' +
+  '                                        <geneRef id="11535623"/>\n' +
+  '                                        <geneRef id="11536586"/>\n' +
+  '                                        <geneRef id="11504470"/>\n' +
+  '                                        <geneRef id="11534398"/>\n' +
+  '                                      </paralogGroup>\n' +
+  '                                      <geneRef id="11454248"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                                      <geneRef id="11163937"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                                        <geneRef id="11387012"/>\n' +
+  '                                        <geneRef id="11439915"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Brassica"/>\n' +
+  '                                        <paralogGroup>\n' +
+  '                                          <geneRef id="11311305"/>\n' +
+  '                                          <geneRef id="11256867"/>\n' +
+  '                                        </paralogGroup>\n' +
+  '                                        <geneRef id="11216885"/>\n' +
+  '                                        <geneRef id="11372777"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <geneRef id="11486386"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="11561474"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="fabids"/>\n' +
+  '                                  <geneRef id="11135497"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Malpighiales"/>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <geneRef id="11070398"/>\n' +
+  '                                      <geneRef id="11078737"/>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <geneRef id="11130056"/>\n' +
+  '                                      <geneRef id="11115196"/>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <geneRef id="10964805"/>\n' +
+  '                                      <geneRef id="11013623"/>\n' +
+  '                                      <geneRef id="10974529"/>\n' +
+  '                                      <geneRef id="10986283"/>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <geneRef id="10945516"/>\n' +
+  '                                      <geneRef id="10955428"/>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="commelinids"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                                <geneRef id="10803937"/>\n' +
+  '                                <geneRef id="10834518"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                                <geneRef id="10798204"/>\n' +
+  '                                <geneRef id="10841780"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Poaceae"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                                  <paralogGroup>\n' +
+  '                                    <geneRef id="10636429"/>\n' +
+  '                                    <geneRef id="10639236"/>\n' +
+  '                                  </paralogGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                                    <geneRef id="10757732"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                                      <geneRef id="10668943"/>\n' +
+  '                                      <geneRef id="10713428"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="BOP clade"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Pooideae"/>\n' +
+  '                                    <geneRef id="10369543"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Triticeae"/>\n' +
+  '                                      <paralogGroup>\n' +
+  '                                        <geneRef id="10544696"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                          <paralogGroup>\n' +
+  '                                            <geneRef id="10465177"/>\n' +
+  '                                            <geneRef id="10564292"/>\n' +
+  '                                          </paralogGroup>\n' +
+  '                                          <geneRef id="10441019"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </paralogGroup>\n' +
+  '                                      <geneRef id="10405887"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Oryza"/>\n' +
+  '                                    <geneRef id="10084100"/>\n' +
+  '                                    <geneRef id="10114957"/>\n' +
+  '                                    <geneRef id="10161159"/>\n' +
+  '                                    <geneRef id="10177629"/>\n' +
+  '                                    <geneRef id="10214828"/>\n' +
+  '                                    <geneRef id="10247621"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Oryza sativa"/>\n' +
+  '                                      <geneRef id="10286119"/>\n' +
+  '                                      <geneRef id="10326046"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Poaceae"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                                  <geneRef id="10749047"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                                    <geneRef id="10661027"/>\n' +
+  '                                    <geneRef id="10727303"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="BOP clade"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Pooideae"/>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Triticeae"/>\n' +
+  '                                        <geneRef id="10396603"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                          <paralogGroup>\n' +
+  '                                            <geneRef id="10527309"/>\n' +
+  '                                            <geneRef id="10499457"/>\n' +
+  '                                          </paralogGroup>\n' +
+  '                                          <geneRef id="10431208"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Triticum"/>\n' +
+  '                                        <geneRef id="10552003"/>\n' +
+  '                                        <geneRef id="10596146"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                    <geneRef id="10366884"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Oryza"/>\n' +
+  '                                    <geneRef id="10102892"/>\n' +
+  '                                    <geneRef id="10166923"/>\n' +
+  '                                    <geneRef id="10209220"/>\n' +
+  '                                    <geneRef id="10271050"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Oryza sativa"/>\n' +
+  '                                      <geneRef id="10308903"/>\n' +
+  '                                      <geneRef id="10347006"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <geneRef id="11603541"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Tracheophyta"/>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="10397431"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Magnoliophyta"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="11583722"/>\n' +
+  '                        <geneRef id="11574451"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Mesangiospermae"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="commelinids"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                                <geneRef id="10794891"/>\n' +
+  '                                <geneRef id="10814018"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                                <geneRef id="10787865"/>\n' +
+  '                                <geneRef id="10831292"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <geneRef id="10620455"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Poaceae"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="10659496"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                                    <geneRef id="10758392"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                                      <geneRef id="10681783"/>\n' +
+  '                                      <geneRef id="10712885"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <geneRef id="10657436"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="BOP clade"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Pooideae"/>\n' +
+  '                                    <paralogGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                        <geneRef id="10439477"/>\n' +
+  '                                        <geneRef id="10497647"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Triticeae"/>\n' +
+  '                                        <paralogGroup>\n' +
+  '                                          <geneRef id="10547231"/>\n' +
+  '                                          <geneRef id="10524683"/>\n' +
+  '                                        </paralogGroup>\n' +
+  '                                        <geneRef id="10406491"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </paralogGroup>\n' +
+  '                                    <geneRef id="10370089"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Oryza"/>\n' +
+  '                                    <geneRef id="10084712"/>\n' +
+  '                                    <geneRef id="10115485"/>\n' +
+  '                                    <geneRef id="10158295"/>\n' +
+  '                                    <geneRef id="10178356"/>\n' +
+  '                                    <geneRef id="10215371"/>\n' +
+  '                                    <geneRef id="10248309"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Oryza sativa"/>\n' +
+  '                                      <geneRef id="10286786"/>\n' +
+  '                                      <geneRef id="10326705"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Poaceae"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <geneRef id="10644535"/>\n' +
+  '                                <geneRef id="10649846"/>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                                <geneRef id="10756429"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                                  <paralogGroup>\n' +
+  '                                    <geneRef id="10732206"/>\n' +
+  '                                    <geneRef id="10711449"/>\n' +
+  '                                  </paralogGroup>\n' +
+  '                                  <geneRef id="10668825"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="BOP clade"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Pooideae"/>\n' +
+  '                                <geneRef id="10367248"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Triticeae"/>\n' +
+  '                                  <paralogGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                      <geneRef id="10437977"/>\n' +
+  '                                      <geneRef id="10493148"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <geneRef id="10476973"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Triticum"/>\n' +
+  '                                      <geneRef id="10547038"/>\n' +
+  '                                      <geneRef id="10593003"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </paralogGroup>\n' +
+  '                                  <geneRef id="10392825"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Oryza"/>\n' +
+  '                                <geneRef id="10102509"/>\n' +
+  '                                <geneRef id="10132798"/>\n' +
+  '                                <geneRef id="10165346"/>\n' +
+  '                                <geneRef id="10184849"/>\n' +
+  '                                <geneRef id="10234095"/>\n' +
+  '                                <geneRef id="10270612"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Oryza sativa"/>\n' +
+  '                                  <geneRef id="10308475"/>\n' +
+  '                                  <geneRef id="10346604"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Pentapetalae"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Solanum"/>\n' +
+  '                              <geneRef id="10873122"/>\n' +
+  '                              <geneRef id="10913304"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Solanum"/>\n' +
+  '                              <geneRef id="10856386"/>\n' +
+  '                              <geneRef id="10893164"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="rosids"/>\n' +
+  '                            <geneRef id="11546685"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="fabids"/>\n' +
+  '                              <geneRef id="11149307"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Malpighiales"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="11127254"/>\n' +
+  '                                  <geneRef id="11097550"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="11090098"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="10979505"/>\n' +
+  '                                  <geneRef id="11015614"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="10940163"/>\n' +
+  '                                <geneRef id="11037291"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="malvids"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                                  <geneRef id="11171536"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                                    <geneRef id="11399180"/>\n' +
+  '                                    <geneRef id="11426373"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Brassica"/>\n' +
+  '                                    <geneRef id="11206879"/>\n' +
+  '                                    <geneRef id="11246731"/>\n' +
+  '                                    <geneRef id="11341034"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                                  <geneRef id="11180896"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                                    <geneRef id="11412157"/>\n' +
+  '                                    <geneRef id="11433755"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Brassica"/>\n' +
+  '                                    <geneRef id="11189883"/>\n' +
+  '                                    <geneRef id="11229807"/>\n' +
+  '                                    <geneRef id="11330234"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="11484185"/>\n' +
+  '                                  <geneRef id="11514149"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="11470768"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                      <geneRef id="10796236"/>\n' +
+  '                      <geneRef id="10815363"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="11598376"/>\n' +
+  '                    <geneRef id="11597593"/>\n' +
+  '                    <geneRef id="11617570"/>\n' +
+  '                    <geneRef id="11623837"/>\n' +
+  '                    <geneRef id="11600515"/>\n' +
+  '                    <geneRef id="11598260"/>\n' +
+  '                    <geneRef id="11606214"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Magnoliophyta"/>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="commelinids"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                        <geneRef id="10776504"/>\n' +
+  '                        <geneRef id="10821586"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <geneRef id="10709407"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                      <geneRef id="10795741"/>\n' +
+  '                      <geneRef id="10814868"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Poaceae"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <geneRef id="10648094"/>\n' +
+  '                          <geneRef id="10621238"/>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                          <geneRef id="10766927"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                            <geneRef id="10693410"/>\n' +
+  '                            <geneRef id="10717804"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="BOP clade"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Pooideae"/>\n' +
+  '                          <geneRef id="10378554"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Triticeae"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                <geneRef id="10430007"/>\n' +
+  '                                <geneRef id="10499555"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Triticum"/>\n' +
+  '                                <geneRef id="10505884"/>\n' +
+  '                                <geneRef id="10595731"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <geneRef id="10526126"/>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="10401038"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Oryza"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="10219483"/>\n' +
+  '                            <geneRef id="10219480"/>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <geneRef id="10088558"/>\n' +
+  '                          <geneRef id="10119212"/>\n' +
+  '                          <geneRef id="10168433"/>\n' +
+  '                          <geneRef id="10183302"/>\n' +
+  '                          <geneRef id="10253271"/>\n' +
+  '                          <geneRef id="10291530"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <geneRef id="11586553"/>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Pentapetalae"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Solanum"/>\n' +
+  '                    <geneRef id="10850353"/>\n' +
+  '                    <geneRef id="10886258"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="rosids"/>\n' +
+  '                    <geneRef id="11557157"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="fabids"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="10999244"/>\n' +
+  '                            <geneRef id="10992049"/>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <geneRef id="10960893"/>\n' +
+  '                          <geneRef id="11040332"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="10983188"/>\n' +
+  '                            <geneRef id="11006924"/>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <geneRef id="10957685"/>\n' +
+  '                          <geneRef id="11028861"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <geneRef id="11151654"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Malpighiales"/>\n' +
+  '                        <geneRef id="11066262"/>\n' +
+  '                        <geneRef id="11123812"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="malvids"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <geneRef id="11494260"/>\n' +
+  '                          <geneRef id="11525612"/>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <geneRef id="11460920"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                          <geneRef id="11382406"/>\n' +
+  '                          <geneRef id="11435437"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Brassica"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="11260395"/>\n' +
+  '                            <geneRef id="11309342"/>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <geneRef id="11220867"/>\n' +
+  '                          <geneRef id="11370688"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Mesangiospermae"/>\n' +
+  '                  <geneRef id="10957686"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="commelinids"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                      <geneRef id="10787637"/>\n' +
+  '                      <geneRef id="10831064"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Poaceae"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="10732136"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="PACMAD clade"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="10645125"/>\n' +
+  '                            <geneRef id="10646638"/>\n' +
+  '                            <geneRef id="10646637"/>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Panicoideae"/>\n' +
+  '                            <geneRef id="10756236"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Andropogoneae"/>\n' +
+  '                              <geneRef id="10692423"/>\n' +
+  '                              <geneRef id="10711213"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="BOP clade"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Triticeae"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <geneRef id="10500545"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Triticum"/>\n' +
+  '                                <geneRef id="10564358"/>\n' +
+  '                                <geneRef id="10590884"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <geneRef id="10488551"/>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="10401268"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Pooideae"/>\n' +
+  '                            <geneRef id="10366268"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Triticeae"/>\n' +
+  '                              <geneRef id="10405164"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Triticinae"/>\n' +
+  '                                <geneRef id="10428668"/>\n' +
+  '                                <geneRef id="10524386"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Oryza"/>\n' +
+  '                          <geneRef id="10082744"/>\n' +
+  '                          <geneRef id="10156145"/>\n' +
+  '                          <geneRef id="10200785"/>\n' +
+  '                          <geneRef id="10213360"/>\n' +
+  '                          <geneRef id="10245951"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Oryza sativa"/>\n' +
+  '                            <geneRef id="10284451"/>\n' +
+  '                            <geneRef id="10324561"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Mesangiospermae"/>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="rosids"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="11557754"/>\n' +
+  '                        <geneRef id="11557753"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="fabids"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <geneRef id="11130324"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Malpighiales"/>\n' +
+  '                            <geneRef id="11079051"/>\n' +
+  '                            <geneRef id="11115448"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <geneRef id="11157553"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="malvids"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <geneRef id="11509154"/>\n' +
+  '                              <geneRef id="11509752"/>\n' +
+  '                              <geneRef id="11480228"/>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="11465659"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <geneRef id="11500188"/>\n' +
+  '                          <geneRef id="11472257"/>\n' +
+  '                          <geneRef id="11479699"/>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Brassica"/>\n' +
+  '                                <geneRef id="11302653"/>\n' +
+  '                                <geneRef id="11363213"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Brassica"/>\n' +
+  '                                <geneRef id="11276326"/>\n' +
+  '                                <geneRef id="11333996"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Brassica"/>\n' +
+  '                                <geneRef id="11208045"/>\n' +
+  '                                <geneRef id="11247898"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="11172818"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                              <geneRef id="11410532"/>\n' +
+  '                              <geneRef id="11432442"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Brassica"/>\n' +
+  '                            <geneRef id="11192167"/>\n' +
+  '                            <geneRef id="11264976"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <geneRef id="10872541"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <geneRef id="11413260"/>\n' +
+  '                        <geneRef id="11410459"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                          <geneRef id="11407126"/>\n' +
+  '                          <geneRef id="11416873"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Brassica"/>\n' +
+  '                          <geneRef id="11197714"/>\n' +
+  '                          <geneRef id="11237239"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <geneRef id="11303930"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Brassica"/>\n' +
+  '                          <geneRef id="11197716"/>\n' +
+  '                          <geneRef id="11237240"/>\n' +
+  '                          <geneRef id="11364698"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Pentapetalae"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Solanum"/>\n' +
+  '                        <geneRef id="10865075"/>\n' +
+  '                        <geneRef id="10903123"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="rosids"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <geneRef id="11052361"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="fabids"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="10986156"/>\n' +
+  '                                  <geneRef id="10974140"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="10955259"/>\n' +
+  '                                <geneRef id="11025543"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Papilionoideae"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="11001139"/>\n' +
+  '                                  <geneRef id="10994228"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="10937640"/>\n' +
+  '                                <geneRef id="11052364"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="11135794"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Malpighiales"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <geneRef id="11064826"/>\n' +
+  '                                <geneRef id="11067050"/>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <geneRef id="11100359"/>\n' +
+  '                                <geneRef id="11104729"/>\n' +
+  '                              </paralogGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="malvids"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Malvaceae"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <geneRef id="11496497"/>\n' +
+  '                                <geneRef id="11504836"/>\n' +
+  '                                <geneRef id="11483742"/>\n' +
+  '                                <geneRef id="11513691"/>\n' +
+  '                                <geneRef id="11528095"/>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <geneRef id="11452862"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Brassica"/>\n' +
+  '                                  <geneRef id="11194363"/>\n' +
+  '                                  <geneRef id="11234003"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Brassica"/>\n' +
+  '                                  <geneRef id="11278961"/>\n' +
+  '                                  <geneRef id="11336447"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <geneRef id="11170099"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                                <geneRef id="11411063"/>\n' +
+  '                                <geneRef id="11432783"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <geneRef id="11475409"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Brassicaceae"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Brassica"/>\n' +
+  '                                <geneRef id="11314835"/>\n' +
+  '                                <geneRef id="11377181"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Brassica"/>\n' +
+  '                                <geneRef id="11223792"/>\n' +
+  '                                <geneRef id="11263537"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Arabidopsis"/>\n' +
+  '                              <geneRef id="11401956"/>\n' +
+  '                              <geneRef id="11428936"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <geneRef id="11548969"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="10396281"/>\n' +
+  '                    <geneRef id="10766795"/>\n' +
+  '                    <geneRef id="10709411"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Musa acuminata"/>\n' +
+  '                      <geneRef id="10802385"/>\n' +
+  '                      <geneRef id="10832967"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Triticeae"/>\n' +
+  '                      <geneRef id="10402855"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Triticinae"/>\n' +
+  '                        <geneRef id="10424865"/>\n' +
+  '                        <geneRef id="10473597"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <geneRef id="10709409"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Brassica"/>\n' +
+  '                  <geneRef id="11277671"/>\n' +
+  '                  <geneRef id="11335100"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </paralogGroup>\n' +
+  '              <geneRef id="10042118"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="10013493"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <geneRef id="5782938"/>\n' +
+  '            <geneRef id="5782939"/>\n' +
+  '            <geneRef id="5782943"/>\n' +
+  '            <geneRef id="5747339"/>\n' +
+  '            <geneRef id="5782942"/>\n' +
+  '            <geneRef id="5778396"/>\n' +
+  '            <geneRef id="5782940"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Dictyosteliida"/>\n' +
+  '              <geneRef id="5907023"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Dictyostelium"/>\n' +
+  '                <geneRef id="5888489"/>\n' +
+  '                <geneRef id="5902140"/>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Dictyostelium"/>\n' +
+  '              <geneRef id="5889714"/>\n' +
+  '              <geneRef id="5896462"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Dictyostelium"/>\n' +
+  '              <geneRef id="5890419"/>\n' +
+  '              <geneRef id="5904342"/>\n' +
+  '            </orthologGroup>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Phytophthora"/>\n' +
+  '              <geneRef id="9855735"/>\n' +
+  '              <geneRef id="9878596"/>\n' +
+  '              <geneRef id="9906949"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="9913292"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Phytophthora"/>\n' +
+  '              <geneRef id="9860970"/>\n' +
+  '              <geneRef id="9883322"/>\n' +
+  '              <geneRef id="9893676"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="9929691"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Stramenopiles"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <geneRef id="9818278"/>\n' +
+  '                <geneRef id="9824326"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <paralogGroup>\n' +
+  '                <geneRef id="9927037"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Phytophthora"/>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="9886376"/>\n' +
+  '                    <geneRef id="9883714"/>\n' +
+  '                    <geneRef id="9886377"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <paralogGroup>\n' +
+  '                    <geneRef id="9897588"/>\n' +
+  '                    <geneRef id="9897586"/>\n' +
+  '                  </paralogGroup>\n' +
+  '                  <geneRef id="9855743"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </paralogGroup>\n' +
+  '              <geneRef id="9933764"/>\n' +
+  '              <geneRef id="9953106"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="9931442"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Oomycetes"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Phytophthora"/>\n' +
+  '                  <geneRef id="9855002"/>\n' +
+  '                  <geneRef id="9880880"/>\n' +
+  '                  <geneRef id="9893598"/>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Peronosporales"/>\n' +
+  '                  <geneRef id="9846007"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Phytophthora"/>\n' +
+  '                    <geneRef id="9855000"/>\n' +
+  '                    <geneRef id="9880882"/>\n' +
+  '                    <geneRef id="9893600"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '              </paralogGroup>\n' +
+  '              <geneRef id="9914608"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="9864612"/>\n' +
+  '            <geneRef id="9924846"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Oomycetes"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <geneRef id="9931609"/>\n' +
+  '                <geneRef id="9931612"/>\n' +
+  '                <geneRef id="9920329"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Peronosporales"/>\n' +
+  '                <geneRef id="9850819"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Phytophthora"/>\n' +
+  '                  <geneRef id="9853163"/>\n' +
+  '                  <geneRef id="9872819"/>\n' +
+  '                  <geneRef id="9892974"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="9913688"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Phytophthora"/>\n' +
+  '              <geneRef id="9878597"/>\n' +
+  '              <geneRef id="9906948"/>\n' +
+  '            </orthologGroup>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <geneRef id="6010597"/>\n' +
+  '            <geneRef id="6033955"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <geneRef id="9759552"/>\n' +
+  '            <geneRef id="9741320"/>\n' +
+  '            <geneRef id="9741322"/>\n' +
+  '            <geneRef id="9730476"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <paralogGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Afrotheria"/>\n' +
+  '              <geneRef id="7383318"/>\n' +
+  '              <geneRef id="7393479"/>\n' +
+  '              <geneRef id="7423188"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="6093285"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Protostomia"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <geneRef id="8592987"/>\n' +
+  '                <geneRef id="9394239"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Lophotrochozoa"/>\n' +
+  '                <geneRef id="9522389"/>\n' +
+  '                <geneRef id="9550270"/>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Metazoa"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Bilateria"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Deuterostomia"/>\n' +
+  '                    <geneRef id="8349164"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Chordata"/>\n' +
+  '                      <geneRef id="7058793"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Vertebrata"/>\n' +
+  '                        <geneRef id="7069767"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Euteleostomi"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Neopterygii"/>\n' +
+  '                            <geneRef id="7084615"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Clupeocephala"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Otophysi"/>\n' +
+  '                                <geneRef id="7267311"/>\n' +
+  '                                <geneRef id="7313395"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Acanthomorphata"/>\n' +
+  '                                <geneRef id="7246166"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Percomorphaceae"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Eupercaria"/>\n' +
+  '                                    <geneRef id="7107012"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Tetraodontidae"/>\n' +
+  '                                      <geneRef id="7125129"/>\n' +
+  '                                      <geneRef id="7153296"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Ovalentaria"/>\n' +
+  '                                    <geneRef id="7240812"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Atherinomorphae"/>\n' +
+  '                                      <geneRef id="7171539"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Poeciliinae"/>\n' +
+  '                                        <geneRef id="7191776"/>\n' +
+  '                                        <geneRef id="7221232"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Sarcopterygii"/>\n' +
+  '                            <geneRef id="7344433"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Tetrapoda"/>\n' +
+  '                              <geneRef id="8285054"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Amniota"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Sauria"/>\n' +
+  '                                  <geneRef id="8279469"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Archelosauria"/>\n' +
+  '                                    <geneRef id="8259215"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Galloanserae"/>\n' +
+  '                                      <geneRef id="8179305"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Phasianidae"/>\n' +
+  '                                        <geneRef id="8186689"/>\n' +
+  '                                        <geneRef id="8200421"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Mammalia"/>\n' +
+  '                                  <geneRef id="7367098"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Theria"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Metatheria"/>\n' +
+  '                                      <geneRef id="8127426"/>\n' +
+  '                                      <geneRef id="8158554"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Eutheria"/>\n' +
+  '                                      <geneRef id="8081407"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Boreoeutheria"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Laurasiatheria"/>\n' +
+  '                                          <geneRef id="8060904"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Chiroptera"/>\n' +
+  '                                            <geneRef id="8000540"/>\n' +
+  '                                            <geneRef id="8028276"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Carnivora"/>\n' +
+  '                                            <geneRef id="7890472"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Caniformia"/>\n' +
+  '                                              <geneRef id="7836453"/>\n' +
+  '                                              <geneRef id="7855267"/>\n' +
+  '                                              <geneRef id="7875688"/>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Cetartiodactyla"/>\n' +
+  '                                            <paralogGroup>\n' +
+  '                                              <geneRef id="7962641"/>\n' +
+  '                                              <geneRef id="7982476"/>\n' +
+  '                                            </paralogGroup>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Bovidae"/>\n' +
+  '                                              <geneRef id="7921170"/>\n' +
+  '                                              <geneRef id="7958354"/>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Euarchontoglires"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Glires"/>\n' +
+  '                                            <geneRef id="7441572"/>\n' +
+  '                                            <geneRef id="7557360"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Simiiformes"/>\n' +
+  '                                            <geneRef id="7736882"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Catarrhini"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Cercopithecinae"/>\n' +
+  '                                                <geneRef id="7575792"/>\n' +
+  '                                                <geneRef id="7602269"/>\n' +
+  '                                                <geneRef id="7622922"/>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Hominoidea"/>\n' +
+  '                                                <geneRef id="7724978"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Hominidae"/>\n' +
+  '                                                  <geneRef id="7702286"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Homininae"/>\n' +
+  '                                                    <geneRef id="7633520"/>\n' +
+  '                                                    <geneRef id="7658071"/>\n' +
+  '                                                    <geneRef id="7684928"/>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Protostomia"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Lophotrochozoa"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Capitella"/>\n' +
+  '                          <geneRef id="9431807"/>\n' +
+  '                          <geneRef id="9480612"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Capitella"/>\n' +
+  '                          <geneRef id="9431806"/>\n' +
+  '                          <geneRef id="9480611"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Mollusca"/>\n' +
+  '                          <geneRef id="9531614"/>\n' +
+  '                          <geneRef id="9605200"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <geneRef id="9597528"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <geneRef id="9520417"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Panarthropoda"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Arthropoda"/>\n' +
+  '                          <paralogGroup>\n' +
+  '                            <geneRef id="8658915"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Pancrustacea"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Crustacea"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="8658914"/>\n' +
+  '                                  <geneRef id="8658913"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="8685530"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Neoptera"/>\n' +
+  '                                <geneRef id="9384480"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Paraneoptera"/>\n' +
+  '                                  <geneRef id="9370390"/>\n' +
+  '                                  <geneRef id="9319349"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Holometabola"/>\n' +
+  '                                  <paralogGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Aculeata"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Apidae"/>\n' +
+  '                                        <geneRef id="9179364"/>\n' +
+  '                                        <geneRef id="9183602"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Formicidae"/>\n' +
+  '                                        <geneRef id="9197915"/>\n' +
+  '                                        <geneRef id="9219480"/>\n' +
+  '                                        <geneRef id="9238036"/>\n' +
+  '                                        <geneRef id="9283492"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Myrmicinae"/>\n' +
+  '                                          <geneRef id="9261860"/>\n' +
+  '                                          <geneRef id="9275972"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <geneRef id="9275975"/>\n' +
+  '                                  </paralogGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Cucujiformia"/>\n' +
+  '                                    <geneRef id="8762961"/>\n' +
+  '                                    <geneRef id="8775784"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <geneRef id="8708522"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Diptera"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Culicidae"/>\n' +
+  '                                      <paralogGroup>\n' +
+  '                                        <geneRef id="9122428"/>\n' +
+  '                                        <geneRef id="9129749"/>\n' +
+  '                                      </paralogGroup>\n' +
+  '                                      <geneRef id="9146746"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Schizophora"/>\n' +
+  '                                      <geneRef id="9105176"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Drosophila"/>\n' +
+  '                                        <geneRef id="8797781"/>\n' +
+  '                                        <geneRef id="8819141"/>\n' +
+  '                                        <geneRef id="9090940"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Sophophora"/>\n' +
+  '                                          <geneRef id="8832593"/>\n' +
+  '                                          <geneRef id="8850883"/>\n' +
+  '                                          <geneRef id="8861216"/>\n' +
+  '                                          <geneRef id="8868678"/>\n' +
+  '                                          <geneRef id="8887140"/>\n' +
+  '                                          <geneRef id="8917325"/>\n' +
+  '                                          <geneRef id="8946280"/>\n' +
+  '                                          <geneRef id="8959766"/>\n' +
+  '                                          <geneRef id="8971400"/>\n' +
+  '                                          <geneRef id="8992443"/>\n' +
+  '                                          <geneRef id="9000203"/>\n' +
+  '                                          <geneRef id="9014181"/>\n' +
+  '                                          <geneRef id="9038225"/>\n' +
+  '                                          <geneRef id="9044893"/>\n' +
+  '                                          <geneRef id="9064609"/>\n' +
+  '                                          <geneRef id="9080050"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Acari"/>\n' +
+  '                            <paralogGroup>\n' +
+  '                              <geneRef id="8615522"/>\n' +
+  '                              <geneRef id="8615408"/>\n' +
+  '                            </paralogGroup>\n' +
+  '                            <geneRef id="8635447"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <geneRef id="8694634"/>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <geneRef id="9397874"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <geneRef id="9513584"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <geneRef id="9677412"/>\n' +
+  '              <geneRef id="9700903"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Opisthokonta"/>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Metazoa"/>\n' +
+  '                  <geneRef id="9669959"/>\n' +
+  '                  <geneRef id="9698997"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Eumetazoa"/>\n' +
+  '                    <paralogGroup>\n' +
+  '                      <geneRef id="9624204"/>\n' +
+  '                      <geneRef id="9618969"/>\n' +
+  '                    </paralogGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Bilateria"/>\n' +
+  '                      <paralogGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Protostomia"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Lophotrochozoa"/>\n' +
+  '                            <geneRef id="9522254"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Annelida"/>\n' +
+  '                              <geneRef id="9410599"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Capitella"/>\n' +
+  '                                <geneRef id="9444206"/>\n' +
+  '                                <geneRef id="9476944"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Mollusca"/>\n' +
+  '                              <geneRef id="9573701"/>\n' +
+  '                              <geneRef id="9595083"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <geneRef id="8646132"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Anopheles"/>\n' +
+  '                          <geneRef id="9119226"/>\n' +
+  '                          <geneRef id="9133724"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </paralogGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Deuterostomia"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Chordata"/>\n' +
+  '                            <geneRef id="7052378"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Ciona"/>\n' +
+  '                              <geneRef id="8310337"/>\n' +
+  '                              <geneRef id="8323672"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Euteleostomi"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Neopterygii"/>\n' +
+  '                                <geneRef id="7078432"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Clupeocephala"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Otophysi"/>\n' +
+  '                                    <geneRef id="7276949"/>\n' +
+  '                                    <geneRef id="7290714"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Acanthomorphata"/>\n' +
+  '                                    <geneRef id="7252762"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Percomorphaceae"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Eupercaria"/>\n' +
+  '                                        <geneRef id="7112069"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Tetraodontidae"/>\n' +
+  '                                          <geneRef id="7128661"/>\n' +
+  '                                          <geneRef id="7145801"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Ovalentaria"/>\n' +
+  '                                        <geneRef id="7233571"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Atherinomorphae"/>\n' +
+  '                                          <geneRef id="7164883"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Poeciliinae"/>\n' +
+  '                                            <geneRef id="7195779"/>\n' +
+  '                                            <geneRef id="7207157"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Sarcopterygii"/>\n' +
+  '                                <geneRef id="7334963"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Tetrapoda"/>\n' +
+  '                                  <geneRef id="8292656"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Amniota"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Sauria"/>\n' +
+  '                                      <geneRef id="8269125"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Archelosauria"/>\n' +
+  '                                        <geneRef id="8255638"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Neognathae"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Passeriformes"/>\n' +
+  '                                            <geneRef id="8223185"/>\n' +
+  '                                            <geneRef id="8229028"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Galloanserae"/>\n' +
+  '                                            <geneRef id="8175740"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Phasianidae"/>\n' +
+  '                                              <geneRef id="8184782"/>\n' +
+  '                                              <geneRef id="8199358"/>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Mammalia"/>\n' +
+  '                                      <geneRef id="7355117"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Theria"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Metatheria"/>\n' +
+  '                                          <geneRef id="8123971"/>\n' +
+  '                                          <geneRef id="8142110"/>\n' +
+  '                                          <geneRef id="8160662"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Eutheria"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Xenarthra"/>\n' +
+  '                                            <geneRef id="8094822"/>\n' +
+  '                                            <geneRef id="8109072"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Afrotheria"/>\n' +
+  '                                            <geneRef id="7376473"/>\n' +
+  '                                            <geneRef id="7389582"/>\n' +
+  '                                            <geneRef id="7418526"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Boreoeutheria"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Laurasiatheria"/>\n' +
+  '                                              <geneRef id="8079514"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Chiroptera"/>\n' +
+  '                                                <geneRef id="8004297"/>\n' +
+  '                                                <geneRef id="8013805"/>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Insectivora"/>\n' +
+  '                                                <geneRef id="8041498"/>\n' +
+  '                                                <geneRef id="8051674"/>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Carnivora"/>\n' +
+  '                                                <geneRef id="7902850"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Caniformia"/>\n' +
+  '                                                  <geneRef id="7843485"/>\n' +
+  '                                                  <geneRef id="7856785"/>\n' +
+  '                                                  <geneRef id="7882921"/>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Cetartiodactyla"/>\n' +
+  '                                                <geneRef id="7914408"/>\n' +
+  '                                                <geneRef id="7980925"/>\n' +
+  '                                                <geneRef id="7993588"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Bovidae"/>\n' +
+  '                                                  <geneRef id="7940366"/>\n' +
+  '                                                  <geneRef id="7960208"/>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Euarchontoglires"/>\n' +
+  '                                              <geneRef id="7816060"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Glires"/>\n' +
+  '                                                <geneRef id="7438663"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Rodentia"/>\n' +
+  '                                                  <geneRef id="7469861"/>\n' +
+  '                                                  <geneRef id="7484731"/>\n' +
+  '                                                  <geneRef id="7558812"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Murinae"/>\n' +
+  '                                                    <geneRef id="7520633"/>\n' +
+  '                                                    <geneRef id="7543281"/>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Primates"/>\n' +
+  '                                                <geneRef id="7792409"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Haplorrhini"/>\n' +
+  '                                                  <geneRef id="7769026"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Simiiformes"/>\n' +
+  '                                                    <geneRef id="7757401"/>\n' +
+  '                                                    <orthologGroup>\n' +
+  '                                                      <property name="TaxRange" value="Catarrhini"/>\n' +
+  '                                                      <orthologGroup>\n' +
+  '                                                        <property name="TaxRange" value="Cercopithecinae"/>\n' +
+  '                                                        <geneRef id="7582310"/>\n' +
+  '                                                        <geneRef id="7605438"/>\n' +
+  '                                                        <geneRef id="7625330"/>\n' +
+  '                                                      </orthologGroup>\n' +
+  '                                                      <orthologGroup>\n' +
+  '                                                        <property name="TaxRange" value="Hominoidea"/>\n' +
+  '                                                        <geneRef id="7726807"/>\n' +
+  '                                                        <orthologGroup>\n' +
+  '                                                          <property name="TaxRange" value="Hominidae"/>\n' +
+  '                                                          <geneRef id="7714722"/>\n' +
+  '                                                          <orthologGroup>\n' +
+  '                                                            <property name="TaxRange" value="Homininae"/>\n' +
+  '                                                            <geneRef id="7647630"/>\n' +
+  '                                                            <geneRef id="7678090"/>\n' +
+  '                                                            <geneRef id="7696938"/>\n' +
+  '                                                          </orthologGroup>\n' +
+  '                                                        </orthologGroup>\n' +
+  '                                                      </orthologGroup>\n' +
+  '                                                    </orthologGroup>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Sarcopterygii"/>\n' +
+  '                            <geneRef id="7347993"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Tetrapoda"/>\n' +
+  '                              <geneRef id="8294991"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Amniota"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Archelosauria"/>\n' +
+  '                                  <geneRef id="8255596"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Neognathae"/>\n' +
+  '                                    <geneRef id="8220149"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Galloanserae"/>\n' +
+  '                                      <geneRef id="8175841"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Phasianidae"/>\n' +
+  '                                        <geneRef id="8196382"/>\n' +
+  '                                        <geneRef id="8207969"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Theria"/>\n' +
+  '                                  <geneRef id="8156404"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Eutheria"/>\n' +
+  '                                    <geneRef id="8108454"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Boreoeutheria"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Laurasiatheria"/>\n' +
+  '                                        <geneRef id="8079824"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Chiroptera"/>\n' +
+  '                                          <geneRef id="7999122"/>\n' +
+  '                                          <geneRef id="8014793"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <geneRef id="8055267"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Carnivora"/>\n' +
+  '                                          <geneRef id="7903134"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Caniformia"/>\n' +
+  '                                            <geneRef id="7843772"/>\n' +
+  '                                            <geneRef id="7847225"/>\n' +
+  '                                            <geneRef id="7867492"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Cetartiodactyla"/>\n' +
+  '                                          <geneRef id="7905945"/>\n' +
+  '                                          <geneRef id="7981236"/>\n' +
+  '                                          <geneRef id="7988353"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Bovidae"/>\n' +
+  '                                            <geneRef id="7940006"/>\n' +
+  '                                            <geneRef id="7960856"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Euarchontoglires"/>\n' +
+  '                                        <geneRef id="7815773"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Glires"/>\n' +
+  '                                          <geneRef id="7439084"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Rodentia"/>\n' +
+  '                                            <geneRef id="7467743"/>\n' +
+  '                                            <geneRef id="7486665"/>\n' +
+  '                                            <geneRef id="7544396"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Murinae"/>\n' +
+  '                                              <geneRef id="7521316"/>\n' +
+  '                                              <geneRef id="7543705"/>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Primates"/>\n' +
+  '                                          <paralogGroup>\n' +
+  '                                            <geneRef id="7779582"/>\n' +
+  '                                            <geneRef id="7794192"/>\n' +
+  '                                          </paralogGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Haplorrhini"/>\n' +
+  '                                            <geneRef id="7768559"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Simiiformes"/>\n' +
+  '                                              <geneRef id="7757748"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Catarrhini"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Cercopithecinae"/>\n' +
+  '                                                  <geneRef id="7581918"/>\n' +
+  '                                                  <geneRef id="7605835"/>\n' +
+  '                                                  <geneRef id="7625605"/>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Hominoidea"/>\n' +
+  '                                                  <geneRef id="7730844"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Hominidae"/>\n' +
+  '                                                    <geneRef id="7715016"/>\n' +
+  '                                                    <orthologGroup>\n' +
+  '                                                      <property name="TaxRange" value="Homininae"/>\n' +
+  '                                                      <geneRef id="7647946"/>\n' +
+  '                                                      <geneRef id="7678477"/>\n' +
+  '                                                    </orthologGroup>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Neopterygii"/>\n' +
+  '                            <geneRef id="7088836"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Clupeocephala"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Otophysi"/>\n' +
+  '                                <geneRef id="7269617"/>\n' +
+  '                                <geneRef id="7295341"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Acanthomorphata"/>\n' +
+  '                                <geneRef id="7264994"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Percomorphaceae"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Eupercaria"/>\n' +
+  '                                    <geneRef id="7112346"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Tetraodontidae"/>\n' +
+  '                                      <geneRef id="7115035"/>\n' +
+  '                                      <geneRef id="7136752"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Ovalentaria"/>\n' +
+  '                                    <geneRef id="7224251"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Atherinomorphae"/>\n' +
+  '                                      <geneRef id="7157317"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Poeciliinae"/>\n' +
+  '                                        <geneRef id="7192875"/>\n' +
+  '                                        <geneRef id="7218024"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Euteleostomi"/>\n' +
+  '                            <geneRef id="7073579"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Sarcopterygii"/>\n' +
+  '                              <geneRef id="7336186"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Amniota"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Sauria"/>\n' +
+  '                                  <geneRef id="8265942"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Archelosauria"/>\n' +
+  '                                    <geneRef id="8263764"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Neognathae"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Passeriformes"/>\n' +
+  '                                        <geneRef id="8213705"/>\n' +
+  '                                        <geneRef id="8237471"/>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Galloanserae"/>\n' +
+  '                                        <geneRef id="8173999"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Phasianidae"/>\n' +
+  '                                          <geneRef id="8189367"/>\n' +
+  '                                          <geneRef id="8207223"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Theria"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Metatheria"/>\n' +
+  '                                    <geneRef id="8120762"/>\n' +
+  '                                    <geneRef id="8138413"/>\n' +
+  '                                    <geneRef id="8164653"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Eutheria"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Xenarthra"/>\n' +
+  '                                      <geneRef id="8094152"/>\n' +
+  '                                      <geneRef id="8114188"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Afrotheria"/>\n' +
+  '                                      <geneRef id="7381518"/>\n' +
+  '                                      <geneRef id="7408157"/>\n' +
+  '                                      <geneRef id="7424946"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Boreoeutheria"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Laurasiatheria"/>\n' +
+  '                                        <geneRef id="8074139"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Chiroptera"/>\n' +
+  '                                          <geneRef id="8010384"/>\n' +
+  '                                          <geneRef id="8020730"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Insectivora"/>\n' +
+  '                                          <geneRef id="8044139"/>\n' +
+  '                                          <geneRef id="8054842"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Carnivora"/>\n' +
+  '                                          <geneRef id="7890146"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Caniformia"/>\n' +
+  '                                            <geneRef id="7824038"/>\n' +
+  '                                            <geneRef id="7846791"/>\n' +
+  '                                            <geneRef id="7868951"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Cetartiodactyla"/>\n' +
+  '                                          <geneRef id="7913277"/>\n' +
+  '                                          <geneRef id="7982415"/>\n' +
+  '                                          <geneRef id="7987850"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Bovidae"/>\n' +
+  '                                            <geneRef id="7939626"/>\n' +
+  '                                            <geneRef id="7959484"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Euarchontoglires"/>\n' +
+  '                                        <geneRef id="7814808"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Glires"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Lagomorpha"/>\n' +
+  '                                            <geneRef id="7428198"/>\n' +
+  '                                            <geneRef id="7455980"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Rodentia"/>\n' +
+  '                                            <geneRef id="7470957"/>\n' +
+  '                                            <geneRef id="7483861"/>\n' +
+  '                                            <geneRef id="7562658"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Murinae"/>\n' +
+  '                                              <geneRef id="7504589"/>\n' +
+  '                                              <geneRef id="7522106"/>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Primates"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Strepsirrhini"/>\n' +
+  '                                            <geneRef id="7786451"/>\n' +
+  '                                            <geneRef id="7794141"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Haplorrhini"/>\n' +
+  '                                            <geneRef id="7770490"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Simiiformes"/>\n' +
+  '                                              <geneRef id="7750671"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Catarrhini"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Cercopithecinae"/>\n' +
+  '                                                  <geneRef id="7567138"/>\n' +
+  '                                                  <geneRef id="7599553"/>\n' +
+  '                                                  <geneRef id="7620802"/>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Hominoidea"/>\n' +
+  '                                                  <geneRef id="7718597"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Hominidae"/>\n' +
+  '                                                    <geneRef id="7711873"/>\n' +
+  '                                                    <orthologGroup>\n' +
+  '                                                      <property name="TaxRange" value="Homininae"/>\n' +
+  '                                                      <geneRef id="7644626"/>\n' +
+  '                                                      <geneRef id="7674130"/>\n' +
+  '                                                      <geneRef id="7694462"/>\n' +
+  '                                                    </orthologGroup>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <geneRef id="8345991"/>\n' +
+  '                          <geneRef id="8350856"/>\n' +
+  '                        </paralogGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <geneRef id="9386686"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Holometabola"/>\n' +
+  '                  <geneRef id="8768263"/>\n' +
+  '                  <geneRef id="9293572"/>\n' +
+  '                  <geneRef id="8793548"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </paralogGroup>\n' +
+  '              <paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Fungi"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Chytridiomycetes"/>\n' +
+  '                    <geneRef id="6099660"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Batrachochytrium dendrobatidis"/>\n' +
+  '                      <geneRef id="6075596"/>\n' +
+  '                      <geneRef id="6084198"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Dikarya"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Basidiomycota"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Puccinia graminis"/>\n' +
+  '                        <geneRef id="6938629"/>\n' +
+  '                        <geneRef id="6953939"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Agaricomycotina"/>\n' +
+  '                        <paralogGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Agaricomycetes"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Agaricomycetidae"/>\n' +
+  '                              <geneRef id="6893835"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Agaricales"/>\n' +
+  '                                <paralogGroup>\n' +
+  '                                  <geneRef id="6840482"/>\n' +
+  '                                  <geneRef id="6849249"/>\n' +
+  '                                </paralogGroup>\n' +
+  '                                <geneRef id="6831839"/>\n' +
+  '                                <geneRef id="6859791"/>\n' +
+  '                                <geneRef id="6867443"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Agaricomycetes incertae sedis"/>\n' +
+  '                              <geneRef id="6663420"/>\n' +
+  '                              <geneRef id="6669180"/>\n' +
+  '                              <geneRef id="6688773"/>\n' +
+  '                              <geneRef id="6699046"/>\n' +
+  '                              <geneRef id="6819581"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Russulales"/>\n' +
+  '                                <geneRef id="6797054"/>\n' +
+  '                                <geneRef id="6803732"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Polyporales"/>\n' +
+  '                                <geneRef id="6747911"/>\n' +
+  '                                <geneRef id="6779399"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Phanerochaetaceae"/>\n' +
+  '                                  <geneRef id="6754473"/>\n' +
+  '                                  <geneRef id="6771451"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Coriolaceae"/>\n' +
+  '                                  <geneRef id="6722832"/>\n' +
+  '                                  <geneRef id="6736750"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <geneRef id="6801952"/>\n' +
+  '                        </paralogGroup>\n' +
+  '                        <geneRef id="6921922"/>\n' +
+  '                        <geneRef id="6918105"/>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Pezizomycotina"/>\n' +
+  '                      <geneRef id="6109271"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="leotiomyceta"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Pleosporineae"/>\n' +
+  '                          <geneRef id="6297333"/>\n' +
+  '                          <geneRef id="6342805"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Phaeosphaeria nodorum"/>\n' +
+  '                            <geneRef id="6313820"/>\n' +
+  '                            <geneRef id="6325203"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <geneRef id="6255939"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="sordariomyceta"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Leotiomycetes"/>\n' +
+  '                            <geneRef id="6357346"/>\n' +
+  '                            <geneRef id="6378655"/>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Sordariomycetes"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Sordariomycetidae"/>\n' +
+  '                              <geneRef id="6513335"/>\n' +
+  '                              <geneRef id="6522682"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Sordariales"/>\n' +
+  '                                <geneRef id="6533767"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Neurospora"/>\n' +
+  '                                  <geneRef id="6538397"/>\n' +
+  '                                  <geneRef id="6549890"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Hypocreomycetidae"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Glomerellales"/>\n' +
+  '                                <geneRef id="6419396"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Colletotrichum"/>\n' +
+  '                                  <geneRef id="6391146"/>\n' +
+  '                                  <geneRef id="6404263"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Hypocreales"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Trichoderma"/>\n' +
+  '                                  <geneRef id="6425295"/>\n' +
+  '                                  <geneRef id="6443461"/>\n' +
+  '                                  <geneRef id="6454713"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Fusarium"/>\n' +
+  '                                  <geneRef id="6462303"/>\n' +
+  '                                  <geneRef id="6486524"/>\n' +
+  '                                  <geneRef id="6494500"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Fungi"/>\n' +
+  '                  <geneRef id="6099636"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Dikarya"/>\n' +
+  '                    <paralogGroup>\n' +
+  '                      <geneRef id="6491188"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Pezizomycotina"/>\n' +
+  '                        <geneRef id="6107556"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="leotiomyceta"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Dothideomycetes"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Dothideomycetidae"/>\n' +
+  '                              <geneRef id="6288474"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Mycosphaerellaceae"/>\n' +
+  '                                <geneRef id="6265159"/>\n' +
+  '                                <geneRef id="6273019"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Pleosporineae"/>\n' +
+  '                              <geneRef id="6297688"/>\n' +
+  '                              <geneRef id="6349929"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Eurotiales"/>\n' +
+  '                            <geneRef id="6247861"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Aspergillaceae"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Penicillium chrysogenum species complex"/>\n' +
+  '                                <geneRef id="6230548"/>\n' +
+  '                                <geneRef id="6242652"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Aspergillus"/>\n' +
+  '                                <geneRef id="6121654"/>\n' +
+  '                                <geneRef id="6129854"/>\n' +
+  '                                <geneRef id="6144379"/>\n' +
+  '                                <geneRef id="6155908"/>\n' +
+  '                                <geneRef id="6160631"/>\n' +
+  '                                <geneRef id="6171165"/>\n' +
+  '                                <geneRef id="6187005"/>\n' +
+  '                                <geneRef id="6219933"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Emericella nidulans"/>\n' +
+  '                                  <geneRef id="6200921"/>\n' +
+  '                                  <geneRef id="6203779"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="sordariomyceta"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Leotiomycetes"/>\n' +
+  '                              <geneRef id="6353686"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Sclerotiniaceae"/>\n' +
+  '                                <geneRef id="6361639"/>\n' +
+  '                                <geneRef id="6386543"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Sordariomycetes"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Sordariomycetidae"/>\n' +
+  '                                <geneRef id="6508637"/>\n' +
+  '                                <geneRef id="6516617"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Sordariales"/>\n' +
+  '                                  <geneRef id="6527080"/>\n' +
+  '                                  <geneRef id="6551654"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Hypocreomycetidae"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Glomerellales"/>\n' +
+  '                                  <geneRef id="6415451"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Colletotrichum"/>\n' +
+  '                                    <geneRef id="6397699"/>\n' +
+  '                                    <geneRef id="6403855"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Hypocreales"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Trichoderma"/>\n' +
+  '                                    <geneRef id="6431059"/>\n' +
+  '                                    <geneRef id="6441357"/>\n' +
+  '                                    <geneRef id="6451735"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Fusarium"/>\n' +
+  '                                    <geneRef id="6473130"/>\n' +
+  '                                    <geneRef id="6474511"/>\n' +
+  '                                    <geneRef id="6487886"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </paralogGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Basidiomycota"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Pucciniomycotina"/>\n' +
+  '                        <geneRef id="6929611"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Puccinia graminis"/>\n' +
+  '                          <geneRef id="6941008"/>\n' +
+  '                          <geneRef id="6968302"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Agaricomycotina"/>\n' +
+  '                        <geneRef id="6921578"/>\n' +
+  '                        <geneRef id="6916358"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Agaricomycetes"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Agaricomycetidae"/>\n' +
+  '                            <geneRef id="6887191"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Agaricales"/>\n' +
+  '                              <paralogGroup>\n' +
+  '                                <geneRef id="6844915"/>\n' +
+  '                                <geneRef id="6840895"/>\n' +
+  '                              </paralogGroup>\n' +
+  '                              <geneRef id="6824764"/>\n' +
+  '                              <geneRef id="6864981"/>\n' +
+  '                              <geneRef id="6868982"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Agaricomycetes incertae sedis"/>\n' +
+  '                            <geneRef id="6644939"/>\n' +
+  '                            <geneRef id="6668783"/>\n' +
+  '                            <geneRef id="6679936"/>\n' +
+  '                            <geneRef id="6695474"/>\n' +
+  '                            <geneRef id="6816466"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Russulales"/>\n' +
+  '                              <geneRef id="6790375"/>\n' +
+  '                              <geneRef id="6798902"/>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Polyporales"/>\n' +
+  '                              <geneRef id="6740248"/>\n' +
+  '                              <geneRef id="6774105"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Phanerochaetaceae"/>\n' +
+  '                                <geneRef id="6760906"/>\n' +
+  '                                <geneRef id="6763236"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Coriolaceae"/>\n' +
+  '                                <geneRef id="6711992"/>\n' +
+  '                                <geneRef id="6726139"/>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <geneRef id="6100038"/>\n' +
+  '              </paralogGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Salpingoecidae"/>\n' +
+  '                <geneRef id="6061603"/>\n' +
+  '                <geneRef id="6071012"/>\n' +
+  '              </orthologGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Ichthyosporea"/>\n' +
+  '                <geneRef id="9710684"/>\n' +
+  '                <geneRef id="9723567"/>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="leotiomyceta"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Dothideomycetes"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Dothideomycetidae"/>\n' +
+  '                  <geneRef id="6293913"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Mycosphaerellaceae"/>\n' +
+  '                    <geneRef id="6259819"/>\n' +
+  '                    <geneRef id="6282514"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Pleosporineae"/>\n' +
+  '                  <geneRef id="6343047"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Phaeosphaeria nodorum"/>\n' +
+  '                    <geneRef id="6311988"/>\n' +
+  '                    <geneRef id="6322593"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '              <geneRef id="6183044"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Sordariomycetes"/>\n' +
+  '                <geneRef id="6515950"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Hypocreomycetidae"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Glomerellales"/>\n' +
+  '                    <geneRef id="6413156"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Colletotrichum"/>\n' +
+  '                      <geneRef id="6396895"/>\n' +
+  '                      <geneRef id="6408974"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Fusarium"/>\n' +
+  '                    <geneRef id="6458800"/>\n' +
+  '                    <geneRef id="6486079"/>\n' +
+  '                    <geneRef id="6492092"/>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="6069674"/>\n' +
+  '            <geneRef id="9691773"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Eumetazoa"/>\n' +
+  '              <geneRef id="9663161"/>\n' +
+  '              <geneRef id="8335813"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="8358181"/>\n' +
+  '            <geneRef id="6062761"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Ecdysozoa"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Chromadorea"/>\n' +
+  '                <geneRef id="8394793"/>\n' +
+  '                <geneRef id="8532643"/>\n' +
+  '                <geneRef id="8487534"/>\n' +
+  '              </orthologGroup>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Panarthropoda"/>\n' +
+  '                <geneRef id="9392238"/>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Crustacea"/>\n' +
+  '                  <geneRef id="8675461"/>\n' +
+  '                  <geneRef id="8683616"/>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="6098594"/>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Chordata"/>\n' +
+  '              <geneRef id="7041673"/>\n' +
+  '              <geneRef id="7365270"/>\n' +
+  '            </orthologGroup>\n' +
+  '            <orthologGroup>\n' +
+  '              <property name="TaxRange" value="Eumetazoa"/>\n' +
+  '              <geneRef id="9616082"/>\n' +
+  '              <orthologGroup>\n' +
+  '                <property name="TaxRange" value="Bilateria"/>\n' +
+  '                <paralogGroup>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Protostomia"/>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Lophotrochozoa"/>\n' +
+  '                      <geneRef id="9514934"/>\n' +
+  '                      <geneRef id="9596235"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Pancrustacea"/>\n' +
+  '                      <geneRef id="8674817"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Holometabola"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Nymphalidae"/>\n' +
+  '                          <geneRef id="8720413"/>\n' +
+  '                          <geneRef id="8751321"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Culicinae"/>\n' +
+  '                          <geneRef id="9141320"/>\n' +
+  '                          <geneRef id="9164753"/>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                  <geneRef id="8606415"/>\n' +
+  '                </paralogGroup>\n' +
+  '                <orthologGroup>\n' +
+  '                  <property name="TaxRange" value="Deuterostomia"/>\n' +
+  '                  <geneRef id="8342419"/>\n' +
+  '                  <orthologGroup>\n' +
+  '                    <property name="TaxRange" value="Chordata"/>\n' +
+  '                    <paralogGroup>\n' +
+  '                      <geneRef id="7040620"/>\n' +
+  '                      <geneRef id="7056313"/>\n' +
+  '                    </paralogGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Ciona"/>\n' +
+  '                      <geneRef id="8310217"/>\n' +
+  '                      <geneRef id="8320601"/>\n' +
+  '                    </orthologGroup>\n' +
+  '                    <orthologGroup>\n' +
+  '                      <property name="TaxRange" value="Euteleostomi"/>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Neopterygii"/>\n' +
+  '                        <geneRef id="7083932"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Clupeocephala"/>\n' +
+  '                          <geneRef id="7270952"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Percomorphaceae"/>\n' +
+  '                            <geneRef id="7122011"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Ovalentaria"/>\n' +
+  '                              <geneRef id="7232998"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Atherinomorphae"/>\n' +
+  '                                <geneRef id="7159915"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Poeciliinae"/>\n' +
+  '                                  <geneRef id="7189689"/>\n' +
+  '                                  <geneRef id="7214493"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                      <orthologGroup>\n' +
+  '                        <property name="TaxRange" value="Sarcopterygii"/>\n' +
+  '                        <geneRef id="7345070"/>\n' +
+  '                        <orthologGroup>\n' +
+  '                          <property name="TaxRange" value="Tetrapoda"/>\n' +
+  '                          <geneRef id="8290871"/>\n' +
+  '                          <orthologGroup>\n' +
+  '                            <property name="TaxRange" value="Amniota"/>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Sauria"/>\n' +
+  '                              <geneRef id="8269599"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Archelosauria"/>\n' +
+  '                                <geneRef id="8256850"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Neognathae"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Passeriformes"/>\n' +
+  '                                    <geneRef id="8220303"/>\n' +
+  '                                    <geneRef id="8229597"/>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Galloanserae"/>\n' +
+  '                                    <geneRef id="8178730"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Phasianidae"/>\n' +
+  '                                      <geneRef id="8185363"/>\n' +
+  '                                      <geneRef id="8199922"/>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                            <orthologGroup>\n' +
+  '                              <property name="TaxRange" value="Mammalia"/>\n' +
+  '                              <geneRef id="7370927"/>\n' +
+  '                              <orthologGroup>\n' +
+  '                                <property name="TaxRange" value="Theria"/>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Metatheria"/>\n' +
+  '                                  <geneRef id="8116312"/>\n' +
+  '                                  <geneRef id="8143392"/>\n' +
+  '                                  <geneRef id="8166892"/>\n' +
+  '                                </orthologGroup>\n' +
+  '                                <orthologGroup>\n' +
+  '                                  <property name="TaxRange" value="Eutheria"/>\n' +
+  '                                  <geneRef id="8086413"/>\n' +
+  '                                  <orthologGroup>\n' +
+  '                                    <property name="TaxRange" value="Boreoeutheria"/>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Laurasiatheria"/>\n' +
+  '                                      <geneRef id="8077688"/>\n' +
+  '                                      <geneRef id="8020067"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Carnivora"/>\n' +
+  '                                        <geneRef id="7895618"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Caniformia"/>\n' +
+  '                                          <geneRef id="7831998"/>\n' +
+  '                                          <geneRef id="7853143"/>\n' +
+  '                                          <geneRef id="7868248"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Cetartiodactyla"/>\n' +
+  '                                        <geneRef id="7908367"/>\n' +
+  '                                        <geneRef id="7979882"/>\n' +
+  '                                        <geneRef id="7989171"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Bovidae"/>\n' +
+  '                                          <geneRef id="7933260"/>\n' +
+  '                                          <geneRef id="7951347"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                    <orthologGroup>\n' +
+  '                                      <property name="TaxRange" value="Euarchontoglires"/>\n' +
+  '                                      <paralogGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Rodentia"/>\n' +
+  '                                          <geneRef id="7474889"/>\n' +
+  '                                          <geneRef id="7555472"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Murinae"/>\n' +
+  '                                            <geneRef id="7516661"/>\n' +
+  '                                            <geneRef id="7523267"/>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Lagomorpha"/>\n' +
+  '                                          <geneRef id="7425992"/>\n' +
+  '                                          <geneRef id="7449034"/>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </paralogGroup>\n' +
+  '                                      <geneRef id="7818841"/>\n' +
+  '                                      <orthologGroup>\n' +
+  '                                        <property name="TaxRange" value="Primates"/>\n' +
+  '                                        <geneRef id="7807839"/>\n' +
+  '                                        <orthologGroup>\n' +
+  '                                          <property name="TaxRange" value="Haplorrhini"/>\n' +
+  '                                          <geneRef id="7770397"/>\n' +
+  '                                          <orthologGroup>\n' +
+  '                                            <property name="TaxRange" value="Simiiformes"/>\n' +
+  '                                            <geneRef id="7738364"/>\n' +
+  '                                            <orthologGroup>\n' +
+  '                                              <property name="TaxRange" value="Catarrhini"/>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Cercopithecinae"/>\n' +
+  '                                                <geneRef id="7564147"/>\n' +
+  '                                                <geneRef id="7590180"/>\n' +
+  '                                                <geneRef id="7613302"/>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                              <orthologGroup>\n' +
+  '                                                <property name="TaxRange" value="Hominoidea"/>\n' +
+  '                                                <geneRef id="7717723"/>\n' +
+  '                                                <orthologGroup>\n' +
+  '                                                  <property name="TaxRange" value="Hominidae"/>\n' +
+  '                                                  <geneRef id="7699612"/>\n' +
+  '                                                  <orthologGroup>\n' +
+  '                                                    <property name="TaxRange" value="Homininae"/>\n' +
+  '                                                    <geneRef id="7630574"/>\n' +
+  '                                                    <geneRef id="7653682"/>\n' +
+  '                                                    <geneRef id="7682436"/>\n' +
+  '                                                  </orthologGroup>\n' +
+  '                                                </orthologGroup>\n' +
+  '                                              </orthologGroup>\n' +
+  '                                            </orthologGroup>\n' +
+  '                                          </orthologGroup>\n' +
+  '                                        </orthologGroup>\n' +
+  '                                      </orthologGroup>\n' +
+  '                                    </orthologGroup>\n' +
+  '                                  </orthologGroup>\n' +
+  '                                </orthologGroup>\n' +
+  '                              </orthologGroup>\n' +
+  '                            </orthologGroup>\n' +
+  '                          </orthologGroup>\n' +
+  '                        </orthologGroup>\n' +
+  '                      </orthologGroup>\n' +
+  '                    </orthologGroup>\n' +
+  '                  </orthologGroup>\n' +
+  '                </orthologGroup>\n' +
+  '              </orthologGroup>\n' +
+  '            </orthologGroup>\n' +
+  '            <geneRef id="6068007"/>\n' +
+  '            <geneRef id="6096847"/>\n' +
+  '          </paralogGroup>\n' +
+  '          <geneRef id="5928082"/>\n' +
+  '        </orthologGroup>\n' +
+  '      </paralogGroup>\n' +
+  '      <geneRef id="1581134"/>\n' +
+  '    </orthologGroup>\n' +
+  '  </groups>\n' +
+  '</orthoXML>\n',
+  "fam_data": [{
+    "taxon": {"strain": "(strain MBIC 11017)", "species": "Acaryochloris marina "},
+    "xrefid": "B0CEP3",
+    "sequence_length": 659,
+    "gc_content": 0.40505050505050505,
+    "protid": "ACAM102973",
+    "id": 1581134
+  }, {
+    "taxon": {"strain": "(strain CCMP3155)", "species": "Vitrella brassicaformis "},
+    "xrefid": "A0A0G4H3T9",
+    "sequence_length": 820,
+    "gc_content": 0.606171335769387,
+    "protid": "VITBC07042",
+    "id": 5747339
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "",
+    "sequence_length": 488,
+    "gc_content": 0.30303030303030304,
+    "protid": "TETTS07065",
+    "id": 5778396
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "I7M157",
+    "sequence_length": 539,
+    "gc_content": 0.33203125,
+    "protid": "TETTS11607",
+    "id": 5782938
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "A4VE03",
+    "sequence_length": 540,
+    "gc_content": 0.3326848249027237,
+    "protid": "TETTS11608",
+    "id": 5782939
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "I7ME56",
+    "sequence_length": 539,
+    "gc_content": 0.3255208333333333,
+    "protid": "TETTS11609",
+    "id": 5782940
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "A4VE04",
+    "sequence_length": 356,
+    "gc_content": 0.3254437869822485,
+    "protid": "TETTS11611",
+    "id": 5782942
+  }, {
+    "taxon": {"strain": "(strain SB210)", "species": "Tetrahymena thermophila "},
+    "xrefid": "I7MIU9",
+    "sequence_length": 539,
+    "gc_content": 0.32619974059662776,
+    "protid": "TETTS11612",
+    "id": 5782943
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium discoideum"},
+    "xrefid": "NOXB_DICDI",
+    "sequence_length": 698,
+    "gc_content": 0.24415832141154029,
+    "protid": "DICDI09248",
+    "id": 5888489
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium discoideum"},
+    "xrefid": "NOXA_DICDI",
+    "sequence_length": 517,
+    "gc_content": 0.3108108108108108,
+    "protid": "DICDI10473",
+    "id": 5889714
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium discoideum"},
+    "xrefid": "NOXC_DICDI",
+    "sequence_length": 1142,
+    "gc_content": 0.2225138524351123,
+    "protid": "DICDI11178",
+    "id": 5890419
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium purpureum"},
+    "xrefid": "F0ZID3",
+    "sequence_length": 524,
+    "gc_content": 0.32634920634920633,
+    "protid": "DICPU04300",
+    "id": 5896462
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium purpureum"},
+    "xrefid": "F0ZZP9",
+    "sequence_length": 600,
+    "gc_content": 0.3017193566278425,
+    "protid": "DICPU09978",
+    "id": 5902140
+  }, {
+    "taxon": {"strain": "", "species": "Dictyostelium purpureum"},
+    "xrefid": "F1A617",
+    "sequence_length": 711,
+    "gc_content": 0.2846441947565543,
+    "protid": "DICPU12180",
+    "id": 5904342
+  }, {
+    "taxon": {"strain": "(strain ATCC 26659 / Pp 5 / PN500)", "species": "Polysphondylium pallidum "},
+    "xrefid": "D3BIK1",
+    "sequence_length": 595,
+    "gc_content": 0.3338926174496644,
+    "protid": "POLPP02544",
+    "id": 5907023
+  }, {
+    "taxon": {"strain": "", "species": "Guillardia theta"},
+    "xrefid": "L1J0R4",
+    "sequence_length": 192,
+    "gc_content": 0.5647668393782384,
+    "protid": "GUITH11236",
+    "id": 5928082
+  }, {
+    "taxon": {"strain": "", "species": "Emiliania huxleyi"},
+    "xrefid": "R1BJN1",
+    "sequence_length": 384,
+    "gc_content": 0.6606060606060606,
+    "protid": "EMIHU03238",
+    "id": 6010597
+  }, {
+    "taxon": {"strain": "", "species": "Emiliania huxleyi"},
+    "xrefid": "R1C1I8",
+    "sequence_length": 454,
+    "gc_content": 0.652014652014652,
+    "protid": "EMIHU26596",
+    "id": 6033955
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2V2B1",
+    "sequence_length": 624,
+    "gc_content": 0.3605333333333333,
+    "protid": "NAEGR02021",
+    "id": 6040834
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2VSJ1",
+    "sequence_length": 674,
+    "gc_content": 0.35259259259259257,
+    "protid": "NAEGR03390",
+    "id": 6042203
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2W2K5",
+    "sequence_length": 665,
+    "gc_content": 0.36186186186186187,
+    "protid": "NAEGR03978",
+    "id": 6042791
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2VJS8",
+    "sequence_length": 627,
+    "gc_content": 0.3535031847133758,
+    "protid": "NAEGR08911",
+    "id": 6047724
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2VLT6",
+    "sequence_length": 630,
+    "gc_content": 0.3676703645007924,
+    "protid": "NAEGR09282",
+    "id": 6048095
+  }, {
+    "taxon": {"strain": "", "species": "Naegleria gruberi"},
+    "xrefid": "D2VM77",
+    "sequence_length": 627,
+    "gc_content": 0.37048832271762205,
+    "protid": "NAEGR14356",
+    "id": 6053169
+  }, {
+    "taxon": {"strain": "", "species": "Monosiga brevicollis"},
+    "xrefid": "A9V5V7",
+    "sequence_length": 613,
+    "gc_content": 0.5325732899022801,
+    "protid": "MONBE07221",
+    "id": 6061603
+  }, {
+    "taxon": {"strain": "", "species": "Monosiga brevicollis"},
+    "xrefid": "A9UZZ7",
+    "sequence_length": 723,
+    "gc_content": 0.5331491712707183,
+    "protid": "MONBE08379",
+    "id": 6062761
+  }, {
+    "taxon": {"strain": "(strain ATCC 50818 / BSB-021)", "species": "Salpingoeca rosetta "},
+    "xrefid": "F2U8H2",
+    "sequence_length": 301,
+    "gc_content": 0.5982339955849889,
+    "protid": "SALR504461",
+    "id": 6068007
+  }, {
+    "taxon": {"strain": "(strain ATCC 50818 / BSB-021)", "species": "Salpingoeca rosetta "},
+    "xrefid": "F2UDN5",
+    "sequence_length": 379,
+    "gc_content": 0.6192982456140351,
+    "protid": "SALR506128",
+    "id": 6069674
+  }, {
+    "taxon": {"strain": "(strain ATCC 50818 / BSB-021)", "species": "Salpingoeca rosetta "},
+    "xrefid": "F2UIK7",
+    "sequence_length": 597,
+    "gc_content": 0.5780379041248607,
+    "protid": "SALR507466",
+    "id": 6071012
+  }, {
+    "taxon": {"strain": "", "species": "Batrachochytrium dendrobatidis"},
+    "xrefid": "",
+    "sequence_length": 541,
+    "gc_content": 0.4274292742927429,
+    "protid": "BATDE00342",
+    "id": 6075596
+  }, {
+    "taxon": {"strain": "(strain JAM81 / FGSC 10211)", "species": "Batrachochytrium dendrobatidis "},
+    "xrefid": "F4P898",
+    "sequence_length": 541,
+    "gc_content": 0.4274292742927429,
+    "protid": "BATDJ00342",
+    "id": 6084198
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0HVR4",
+    "sequence_length": 529,
+    "gc_content": 0.4867924528301887,
+    "protid": "SPIPN00827",
+    "id": 6093285
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0HFM5",
+    "sequence_length": 611,
+    "gc_content": 0.5136165577342048,
+    "protid": "SPIPN04389",
+    "id": 6096847
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0HB32",
+    "sequence_length": 612,
+    "gc_content": 0.49864056552474173,
+    "protid": "SPIPN06136",
+    "id": 6098594
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0H960",
+    "sequence_length": 521,
+    "gc_content": 0.49744572158365263,
+    "protid": "SPIPN07178",
+    "id": 6099636
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0H6T7",
+    "sequence_length": 555,
+    "gc_content": 0.5149880095923262,
+    "protid": "SPIPN07202",
+    "id": 6099660
+  }, {
+    "taxon": {"strain": "", "species": "Spizellomyces punctatus"},
+    "xrefid": "A0A0L0H758",
+    "sequence_length": 752,
+    "gc_content": 0.4692341744134573,
+    "protid": "SPIPN07580",
+    "id": 6100038
+  }, {
+    "taxon": {"strain": "(strain Mel28)", "species": "Tuber melanosporum "},
+    "xrefid": "D5G6A8",
+    "sequence_length": 546,
+    "gc_content": 0.48567946374162096,
+    "protid": "TUBMM00869",
+    "id": 6107556
+  }, {
+    "taxon": {"strain": "(strain Mel28)", "species": "Tuber melanosporum "},
+    "xrefid": "D5GB73",
+    "sequence_length": 551,
+    "gc_content": 0.4716183574879227,
+    "protid": "TUBMM02584",
+    "id": 6109271
+  }, {
+    "taxon": {"strain": "", "species": "Aspergillus aculeatus"},
+    "xrefid": "A0A1L9WPH0",
+    "sequence_length": 549,
+    "gc_content": 0.5339393939393939,
+    "protid": "ASPAC07474",
+    "id": 6121654
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 1007 / CBS 513.65 / DSM 816 / NCTC 3887 / NRRL 1)",
+      "species": "Aspergillus clavatus "
+    },
+    "xrefid": "A1CUH5",
+    "sequence_length": 550,
+    "gc_content": 0.5680580762250453,
+    "protid": "ASPCL04855",
+    "id": 6129854
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 1020 / DSM 3700 / CBS 544.65 / FGSC A1164 / JCM 1740 / NRRL 181 / WB 181)",
+      "species": "Neosartorya fischeri "
+    },
+    "xrefid": "A1DP56",
+    "sequence_length": 549,
+    "gc_content": 0.563030303030303,
+    "protid": "NEOFI10259",
+    "id": 6144379
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 200026 / FGSC A1120 / NRRL 3357 / JCM 12722 / SRRC 167)",
+      "species": "Aspergillus flavus "
+    },
+    "xrefid": "B8N436",
+    "sequence_length": 534,
+    "gc_content": 0.514018691588785,
+    "protid": "ASPFN11386",
+    "id": 6155908
+  }, {
+    "taxon": {"strain": "", "species": "Aspergillus glaucus"},
+    "xrefid": "",
+    "sequence_length": 559,
+    "gc_content": 0.5202380952380953,
+    "protid": "ASPGL02622",
+    "id": 6160631
+  }, {
+    "taxon": {"strain": "(strain ATCC 42149 / RIB 40)", "species": "Aspergillus oryzae "},
+    "xrefid": "Q2ULC8",
+    "sequence_length": 549,
+    "gc_content": 0.5072727272727273,
+    "protid": "ASPOR03100",
+    "id": 6171165
+  }, {
+    "taxon": {"strain": "(strain NIH 2624 / FGSC A1156)", "species": "Aspergillus terreus "},
+    "xrefid": "Q0CBV1",
+    "sequence_length": 677,
+    "gc_content": 0.6135693215339233,
+    "protid": "ASPTN02971",
+    "id": 6183044
+  }, {
+    "taxon": {"strain": "(strain NIH 2624 / FGSC A1156)", "species": "Aspergillus terreus "},
+    "xrefid": "Q0CSG3",
+    "sequence_length": 551,
+    "gc_content": 0.6044685990338164,
+    "protid": "ASPTN06932",
+    "id": 6187005
+  }, {
+    "taxon": {"strain": "", "species": "Emericella nidulans"},
+    "xrefid": "Q8J0N4",
+    "sequence_length": 550,
+    "gc_content": 0.5390199637023594,
+    "protid": "EMEND10444",
+    "id": 6200921
+  }, {
+    "taxon": {
+      "strain": "(strain FGSC A4 / ATCC 38163 / CBS 112.46 / NRRL 194 / M139)",
+      "species": "Emericella nidulans "
+    },
+    "xrefid": "A0A1U8QTU0",
+    "sequence_length": 550,
+    "gc_content": 0.5390199637023594,
+    "protid": "EMENI02628",
+    "id": 6203779
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC MYA-4609 / Af293 / CBS 101355 / FGSC A1100)",
+      "species": "Neosartorya fumigata "
+    },
+    "xrefid": "Q4WLJ1",
+    "sequence_length": 549,
+    "gc_content": 0.5527272727272727,
+    "protid": "ASPFU08272",
+    "id": 6219933
+  }, {
+    "taxon": {"strain": "", "species": "Penicillium chrysogenum"},
+    "xrefid": "",
+    "sequence_length": 554,
+    "gc_content": 0.5117117117117117,
+    "protid": "PENCH09257",
+    "id": 6230548
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 28089 / DSM 1075 / NRRL 1951 / Wisconsin 54-1255)",
+      "species": "Penicillium rubens "
+    },
+    "xrefid": "B6HP04",
+    "sequence_length": 554,
+    "gc_content": 0.512912912912913,
+    "protid": "PENRW09965",
+    "id": 6242652
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 10500 / CBS 375.48 / QM 6759 / NRRL 1006)",
+      "species": "Talaromyces stipitatus "
+    },
+    "xrefid": "B8LZ61",
+    "sequence_length": 549,
+    "gc_content": 0.5054545454545455,
+    "protid": "TALSN02404",
+    "id": 6247861
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 10500 / CBS 375.48 / QM 6759 / NRRL 1006)",
+      "species": "Talaromyces stipitatus "
+    },
+    "xrefid": "B8MNF6",
+    "sequence_length": 577,
+    "gc_content": 0.4734717416378316,
+    "protid": "TALSN10482",
+    "id": 6255939
+  }, {
+    "taxon": {"strain": "", "species": "Passalora fulva"},
+    "xrefid": "",
+    "sequence_length": 649,
+    "gc_content": 0.5492307692307692,
+    "protid": "PASFU01348",
+    "id": 6259819
+  }, {
+    "taxon": {"strain": "", "species": "Passalora fulva"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.529868578255675,
+    "protid": "PASFU06688",
+    "id": 6265159
+  }, {
+    "taxon": {"strain": "", "species": "Zymoseptoria tritici"},
+    "xrefid": "A0A1X7RE92",
+    "sequence_length": 554,
+    "gc_content": 0.5405405405405406,
+    "protid": "ZYMTR00591",
+    "id": 6273019
+  }, {
+    "taxon": {"strain": "", "species": "Zymoseptoria tritici"},
+    "xrefid": "",
+    "sequence_length": 693,
+    "gc_content": 0.5384245917387128,
+    "protid": "ZYMTR10086",
+    "id": 6282514
+  }, {
+    "taxon": {"strain": "", "species": "Aureobasidium pullulans"},
+    "xrefid": "",
+    "sequence_length": 560,
+    "gc_content": 0.5062388591800356,
+    "protid": "AURPU05132",
+    "id": 6288474
+  }, {
+    "taxon": {"strain": "", "species": "Aureobasidium pullulans"},
+    "xrefid": "",
+    "sequence_length": 729,
+    "gc_content": 0.502283105022831,
+    "protid": "AURPU10571",
+    "id": 6293913
+  }, {
+    "taxon": {"strain": "(strain JN3 / isolate v23.1.3 / race Av1-4-5-6-7-8)", "species": "Leptosphaeria maculans "},
+    "xrefid": "E5A3M8",
+    "sequence_length": 561,
+    "gc_content": 0.5249110320284698,
+    "protid": "LEPMJ03183",
+    "id": 6297333
+  }, {
+    "taxon": {"strain": "(strain JN3 / isolate v23.1.3 / race Av1-4-5-6-7-8)", "species": "Leptosphaeria maculans "},
+    "xrefid": "E5A1S5",
+    "sequence_length": 552,
+    "gc_content": 0.5268233875828813,
+    "protid": "LEPMJ03538",
+    "id": 6297688
+  }, {
+    "taxon": {"strain": "", "species": "Phaeosphaeria nodorum"},
+    "xrefid": "",
+    "sequence_length": 654,
+    "gc_content": 0.5089058524173028,
+    "protid": "PHAND05372",
+    "id": 6311988
+  }, {
+    "taxon": {"strain": "", "species": "Phaeosphaeria nodorum"},
+    "xrefid": "",
+    "sequence_length": 565,
+    "gc_content": 0.5082449941107184,
+    "protid": "PHAND07204",
+    "id": 6313820
+  }, {
+    "taxon": {"strain": "(strain SN15 / ATCC MYA-4574 / FGSC 10173)", "species": "Phaeosphaeria nodorum "},
+    "xrefid": "Q0UAW8",
+    "sequence_length": 654,
+    "gc_content": 0.5089058524173028,
+    "protid": "PHANO00002",
+    "id": 6322593
+  }, {
+    "taxon": {"strain": "(strain SN15 / ATCC MYA-4574 / FGSC 10173)", "species": "Phaeosphaeria nodorum "},
+    "xrefid": "",
+    "sequence_length": 578,
+    "gc_content": 0.5060449050086355,
+    "protid": "PHANO02612",
+    "id": 6325203
+  }, {
+    "taxon": {"strain": "", "species": "Cochliobolus lunatus"},
+    "xrefid": "V9SDP2",
+    "sequence_length": 561,
+    "gc_content": 0.5272835112692764,
+    "protid": "COCLU03725",
+    "id": 6342805
+  }, {
+    "taxon": {"strain": "", "species": "Cochliobolus lunatus"},
+    "xrefid": "",
+    "sequence_length": 665,
+    "gc_content": 0.508008008008008,
+    "protid": "COCLU03967",
+    "id": 6343047
+  }, {
+    "taxon": {"strain": "", "species": "Cochliobolus lunatus"},
+    "xrefid": "V9SCI7",
+    "sequence_length": 549,
+    "gc_content": 0.5357575757575758,
+    "protid": "COCLU10849",
+    "id": 6349929
+  }, {
+    "taxon": {"strain": "", "species": "Blumeria graminis"},
+    "xrefid": "",
+    "sequence_length": 555,
+    "gc_content": 0.43225419664268583,
+    "protid": "BLUGR02477",
+    "id": 6353686
+  }, {
+    "taxon": {"strain": "", "species": "Blumeria graminis"},
+    "xrefid": "",
+    "sequence_length": 575,
+    "gc_content": 0.4351851851851852,
+    "protid": "BLUGR06137",
+    "id": 6357346
+  }, {
+    "taxon": {"strain": "(strain B05.10)", "species": "Botryotinia fuckeliana "},
+    "xrefid": "",
+    "sequence_length": 553,
+    "gc_content": 0.4500601684717208,
+    "protid": "BOTFB03972",
+    "id": 6361639
+  }, {
+    "taxon": {"strain": "(strain ATCC 18683 / 1980 / Ss-1)", "species": "Sclerotinia sclerotiorum "},
+    "xrefid": "A7F0Q3",
+    "sequence_length": 581,
+    "gc_content": 0.4020618556701031,
+    "protid": "SCLS104689",
+    "id": 6378655
+  }, {
+    "taxon": {"strain": "(strain ATCC 18683 / 1980 / Ss-1)", "species": "Sclerotinia sclerotiorum "},
+    "xrefid": "A7EK15",
+    "sequence_length": 541,
+    "gc_content": 0.4575645756457565,
+    "protid": "SCLS112577",
+    "id": 6386543
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum graminicola"},
+    "xrefid": "",
+    "sequence_length": 568,
+    "gc_content": 0.562390158172232,
+    "protid": "COLGR02734",
+    "id": 6391146
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum graminicola"},
+    "xrefid": "",
+    "sequence_length": 828,
+    "gc_content": 0.6658624849215923,
+    "protid": "COLGR08483",
+    "id": 6396895
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum graminicola"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5591397849462365,
+    "protid": "COLGR09287",
+    "id": 6397699
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum sublineola"},
+    "xrefid": "A0A066XPH2",
+    "sequence_length": 557,
+    "gc_content": 0.5543608124253285,
+    "protid": "COLSU03424",
+    "id": 6403855
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum sublineola"},
+    "xrefid": "A0A066WXB9",
+    "sequence_length": 568,
+    "gc_content": 0.5571177504393673,
+    "protid": "COLSU03832",
+    "id": 6404263
+  }, {
+    "taxon": {"strain": "", "species": "Colletotrichum sublineola"},
+    "xrefid": "A0A066X1M4",
+    "sequence_length": 827,
+    "gc_content": 0.6461352657004831,
+    "protid": "COLSU08543",
+    "id": 6408974
+  }, {
+    "taxon": {"strain": "", "species": "Verticillium dahliae"},
+    "xrefid": "",
+    "sequence_length": 775,
+    "gc_content": 0.6000859106529209,
+    "protid": "VERDA00032",
+    "id": 6413156
+  }, {
+    "taxon": {"strain": "", "species": "Verticillium dahliae"},
+    "xrefid": "",
+    "sequence_length": 555,
+    "gc_content": 0.5665467625899281,
+    "protid": "VERDA02327",
+    "id": 6415451
+  }, {
+    "taxon": {"strain": "", "species": "Verticillium dahliae"},
+    "xrefid": "",
+    "sequence_length": 573,
+    "gc_content": 0.5307781649245064,
+    "protid": "VERDA06272",
+    "id": 6419396
+  }, {
+    "taxon": {"strain": "(strain ATCC 20476 / IMI 206040)", "species": "Hypocrea atroviridis "},
+    "xrefid": "G9NXK6",
+    "sequence_length": 570,
+    "gc_content": 0.5674255691768827,
+    "protid": "HYPAI01642",
+    "id": 6425295
+  }, {
+    "taxon": {"strain": "(strain ATCC 20476 / IMI 206040)", "species": "Hypocrea atroviridis "},
+    "xrefid": "G9PA01",
+    "sequence_length": 557,
+    "gc_content": 0.525089605734767,
+    "protid": "HYPAI07406",
+    "id": 6431059
+  }, {
+    "taxon": {"strain": "", "species": "Hypocrea jecorina"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5579450418160096,
+    "protid": "HYPJE05847",
+    "id": 6441357
+  }, {
+    "taxon": {"strain": "", "species": "Hypocrea jecorina"},
+    "xrefid": "",
+    "sequence_length": 570,
+    "gc_content": 0.6088733216579101,
+    "protid": "HYPJE07951",
+    "id": 6443461
+  }, {
+    "taxon": {"strain": "(strain Gv29-8 / FGSC 10586)", "species": "Hypocrea virens "},
+    "xrefid": "G9MIM8",
+    "sequence_length": 557,
+    "gc_content": 0.538231780167264,
+    "protid": "HYPVG07097",
+    "id": 6451735
+  }, {
+    "taxon": {"strain": "(strain Gv29-8 / FGSC 10586)", "species": "Hypocrea virens "},
+    "xrefid": "G9MPG4",
+    "sequence_length": 570,
+    "gc_content": 0.5592527729130181,
+    "protid": "HYPVG10075",
+    "id": 6454713
+  }, {
+    "taxon": {
+      "strain": "(strain 4287 / CBS 123668 / FGSC 9935 / NRRL 34936)",
+      "species": "Fusarium oxysporum f. sp. lycopersici "
+    },
+    "xrefid": "A0A0D2YAG2",
+    "sequence_length": 748,
+    "gc_content": 0.5191622103386809,
+    "protid": "FUSO401755",
+    "id": 6458800
+  }, {
+    "taxon": {
+      "strain": "(strain 4287 / CBS 123668 / FGSC 9935 / NRRL 34936)",
+      "species": "Fusarium oxysporum f. sp. lycopersici "
+    },
+    "xrefid": "A0A0D2Y8X0",
+    "sequence_length": 481,
+    "gc_content": 0.5148995148995149,
+    "protid": "FUSO405258",
+    "id": 6462303
+  }, {
+    "taxon": {
+      "strain": "(strain 4287 / CBS 123668 / FGSC 9935 / NRRL 34936)",
+      "species": "Fusarium oxysporum f. sp. lycopersici "
+    },
+    "xrefid": "A0A0D2XB03",
+    "sequence_length": 486,
+    "gc_content": 0.5267489711934157,
+    "protid": "FUSO416085",
+    "id": 6473130
+  }, {
+    "taxon": {"strain": "", "species": "Gibberella zeae"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5221027479091995,
+    "protid": "GIBZA00876",
+    "id": 6474511
+  }, {
+    "taxon": {"strain": "", "species": "Gibberella zeae"},
+    "xrefid": "",
+    "sequence_length": 749,
+    "gc_content": 0.5057777777777778,
+    "protid": "GIBZA12444",
+    "id": 6486079
+  }, {
+    "taxon": {"strain": "", "species": "Gibberella zeae"},
+    "xrefid": "",
+    "sequence_length": 574,
+    "gc_content": 0.5223188405797101,
+    "protid": "GIBZA12889",
+    "id": 6486524
+  }, {
+    "taxon": {"strain": "", "species": "Nectria haematococca"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5531660692951016,
+    "protid": "NECHA00931",
+    "id": 6487886
+  }, {
+    "taxon": {"strain": "", "species": "Nectria haematococca"},
+    "xrefid": "",
+    "sequence_length": 560,
+    "gc_content": 0.5080213903743316,
+    "protid": "NECHA04233",
+    "id": 6491188
+  }, {
+    "taxon": {"strain": "", "species": "Nectria haematococca"},
+    "xrefid": "",
+    "sequence_length": 728,
+    "gc_content": 0.5276634659350709,
+    "protid": "NECHA05137",
+    "id": 6492092
+  }, {
+    "taxon": {"strain": "", "species": "Nectria haematococca"},
+    "xrefid": "",
+    "sequence_length": 572,
+    "gc_content": 0.5445026178010471,
+    "protid": "NECHA07545",
+    "id": 6494500
+  }, {
+    "taxon": {"strain": "", "species": "Cryphonectria parasitica"},
+    "xrefid": "",
+    "sequence_length": 553,
+    "gc_content": 0.5541516245487365,
+    "protid": "CRYPA06011",
+    "id": 6508637
+  }, {
+    "taxon": {"strain": "", "species": "Cryphonectria parasitica"},
+    "xrefid": "",
+    "sequence_length": 577,
+    "gc_content": 0.5957324106113033,
+    "protid": "CRYPA10709",
+    "id": 6513335
+  }, {
+    "taxon": {"strain": "", "species": "Magnaporthe grisea"},
+    "xrefid": "",
+    "sequence_length": 849,
+    "gc_content": 0.6372549019607843,
+    "protid": "MAGGR01761",
+    "id": 6515950
+  }, {
+    "taxon": {"strain": "", "species": "Magnaporthe grisea"},
+    "xrefid": "A6ZIB7",
+    "sequence_length": 553,
+    "gc_content": 0.5469314079422383,
+    "protid": "MAGGR02428",
+    "id": 6516617
+  }, {
+    "taxon": {"strain": "", "species": "Magnaporthe grisea"},
+    "xrefid": "A6ZIB8",
+    "sequence_length": 582,
+    "gc_content": 0.534019439679817,
+    "protid": "MAGGR08493",
+    "id": 6522682
+  }, {
+    "taxon": {"strain": "", "species": "Thielavia heterothallica"},
+    "xrefid": "",
+    "sequence_length": 553,
+    "gc_content": 0.6022864019253911,
+    "protid": "THIHE00254",
+    "id": 6527080
+  }, {
+    "taxon": {"strain": "", "species": "Thielavia heterothallica"},
+    "xrefid": "",
+    "sequence_length": 583,
+    "gc_content": 0.5787671232876712,
+    "protid": "THIHE06941",
+    "id": 6533767
+  }, {
+    "taxon": {
+      "strain": "(strain ATCC 24698 / 74-OR23-1A / CBS 708.71 / DSM 1257 / FGSC 987)",
+      "species": "Neurospora crassa "
+    },
+    "xrefid": "V5IKM9",
+    "sequence_length": 581,
+    "gc_content": 0.5446735395189003,
+    "protid": "NEUCR02484",
+    "id": 6538397
+  }, {
+    "taxon": {"strain": "(strain FGSC 2509 / P0656)", "species": "Neurospora tetrasperma "},
+    "xrefid": "G4UYG7",
+    "sequence_length": 581,
+    "gc_content": 0.5435280641466208,
+    "protid": "NEUT906408",
+    "id": 6549890
+  }, {
+    "taxon": {"strain": "(strain FGSC 2509 / P0656)", "species": "Neurospora tetrasperma "},
+    "xrefid": "G4U839",
+    "sequence_length": 553,
+    "gc_content": 0.5403128760529483,
+    "protid": "NEUT908172",
+    "id": 6551654
+  }, {
+    "taxon": {"strain": "(strain TFB-10046 / SS5)", "species": "Auricularia subglabra "},
+    "xrefid": "",
+    "sequence_length": 559,
+    "gc_content": 0.611904761904762,
+    "protid": "AURST00636",
+    "id": 6644939
+  }, {
+    "taxon": {"strain": "(strain TFB-10046 / SS5)", "species": "Auricularia subglabra "},
+    "xrefid": "J0WTA8",
+    "sequence_length": 614,
+    "gc_content": 0.6373983739837399,
+    "protid": "AURST19117",
+    "id": 6663420
+  }, {
+    "taxon": {"strain": "(strain HHB-11173)", "species": "Punctularia strigosozonata "},
+    "xrefid": "",
+    "sequence_length": 559,
+    "gc_content": 0.5869047619047619,
+    "protid": "PUNST01040",
+    "id": 6668783
+  }, {
+    "taxon": {"strain": "(strain HHB-11173)", "species": "Punctularia strigosozonata "},
+    "xrefid": "",
+    "sequence_length": 549,
+    "gc_content": 0.573939393939394,
+    "protid": "PUNST01437",
+    "id": 6669180
+  }, {
+    "taxon": {"strain": "", "species": "Gloeophyllum trabeum"},
+    "xrefid": "",
+    "sequence_length": 562,
+    "gc_content": 0.5470692717584369,
+    "protid": "GLOTR00698",
+    "id": 6679936
+  }, {
+    "taxon": {"strain": "", "species": "Gloeophyllum trabeum"},
+    "xrefid": "",
+    "sequence_length": 604,
+    "gc_content": 0.5741046831955923,
+    "protid": "GLOTR09535",
+    "id": 6688773
+  }, {
+    "taxon": {"strain": "(strain MF3/22)", "species": "Fomitiporia mediterranea "},
+    "xrefid": "",
+    "sequence_length": 558,
+    "gc_content": 0.5163983303518187,
+    "protid": "FOMME04454",
+    "id": 6695474
+  }, {
+    "taxon": {"strain": "(strain MF3/22)", "species": "Fomitiporia mediterranea "},
+    "xrefid": "",
+    "sequence_length": 604,
+    "gc_content": 0.5024793388429752,
+    "protid": "FOMME08026",
+    "id": 6699046
+  }, {
+    "taxon": {"strain": "(strain FP-101664)", "species": "Trametes versicolor "},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5925925925925926,
+    "protid": "TRAVS00872",
+    "id": 6711992
+  }, {
+    "taxon": {"strain": "(strain FP-101664)", "species": "Trametes versicolor "},
+    "xrefid": "",
+    "sequence_length": 606,
+    "gc_content": 0.5958264689730917,
+    "protid": "TRAVS11712",
+    "id": 6722832
+  }, {
+    "taxon": {"strain": "(strain MD-104)", "species": "Wolfiporia cocos "},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5842293906810035,
+    "protid": "WOLCO00809",
+    "id": 6726139
+  }, {
+    "taxon": {"strain": "(strain MD-104)", "species": "Wolfiporia cocos "},
+    "xrefid": "",
+    "sequence_length": 608,
+    "gc_content": 0.6037219485495348,
+    "protid": "WOLCO11420",
+    "id": 6736750
+  }, {
+    "taxon": {"strain": "(strain FP-58527)", "species": "Fomitopsis pinicola "},
+    "xrefid": "S8FRL6",
+    "sequence_length": 557,
+    "gc_content": 0.5872162485065711,
+    "protid": "FOMPI02192",
+    "id": 6740248
+  }, {
+    "taxon": {"strain": "(strain FP-58527)", "species": "Fomitopsis pinicola "},
+    "xrefid": "S8DUX1",
+    "sequence_length": 601,
+    "gc_content": 0.5930232558139535,
+    "protid": "FOMPI09855",
+    "id": 6747911
+  }, {
+    "taxon": {"strain": "", "species": "Phanerochaete chrysosporium"},
+    "xrefid": "",
+    "sequence_length": 609,
+    "gc_content": 0.5688524590163935,
+    "protid": "PHACH02605",
+    "id": 6754473
+  }, {
+    "taxon": {"strain": "", "species": "Phanerochaete chrysosporium"},
+    "xrefid": "",
+    "sequence_length": 547,
+    "gc_content": 0.559610705596107,
+    "protid": "PHACH09038",
+    "id": 6760906
+  }, {
+    "taxon": {"strain": "", "species": "Phlebiopsis gigantea"},
+    "xrefid": "A0A0C3P0W4",
+    "sequence_length": 559,
+    "gc_content": 0.5648809523809524,
+    "protid": "PHLGI01434",
+    "id": 6763236
+  }, {
+    "taxon": {"strain": "", "species": "Phlebiopsis gigantea"},
+    "xrefid": "A0A0C3NF68",
+    "sequence_length": 610,
+    "gc_content": 0.5624659028914348,
+    "protid": "PHLGI09649",
+    "id": 6771451
+  }, {
+    "taxon": {"strain": "(strain LYAD-421)", "species": "Dichomitus squalens "},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.5919952210274791,
+    "protid": "DICSQ00423",
+    "id": 6774105
+  }, {
+    "taxon": {"strain": "(strain LYAD-421)", "species": "Dichomitus squalens "},
+    "xrefid": "R7T012",
+    "sequence_length": 597,
+    "gc_content": 0.5947603121516165,
+    "protid": "DICSQ05717",
+    "id": 6779399
+  }, {
+    "taxon": {"strain": "", "species": "Heterobasidion annosum"},
+    "xrefid": "",
+    "sequence_length": 558,
+    "gc_content": 0.5420393559928444,
+    "protid": "HETAN04449",
+    "id": 6790375
+  }, {
+    "taxon": {"strain": "", "species": "Heterobasidion annosum"},
+    "xrefid": "",
+    "sequence_length": 601,
+    "gc_content": 0.5614617940199336,
+    "protid": "HETAN11128",
+    "id": 6797054
+  }, {
+    "taxon": {"strain": "(strain FP-91666)", "species": "Stereum hirsutum "},
+    "xrefid": "",
+    "sequence_length": 560,
+    "gc_content": 0.5496137849079026,
+    "protid": "STEHR00814",
+    "id": 6798902
+  }, {
+    "taxon": {"strain": "(strain FP-91666)", "species": "Stereum hirsutum "},
+    "xrefid": "",
+    "sequence_length": 595,
+    "gc_content": 0.5363534675615212,
+    "protid": "STEHR03864",
+    "id": 6801952
+  }, {
+    "taxon": {"strain": "(strain FP-91666)", "species": "Stereum hirsutum "},
+    "xrefid": "",
+    "sequence_length": 608,
+    "gc_content": 0.5205254515599343,
+    "protid": "STEHR05644",
+    "id": 6803732
+  }, {
+    "taxon": {"strain": "(strain DSM 11827)", "species": "Serendipita indica "},
+    "xrefid": "G4TGA3",
+    "sequence_length": 564,
+    "gc_content": 0.5681415929203539,
+    "protid": "SERID04354",
+    "id": 6816466
+  }, {
+    "taxon": {"strain": "(strain DSM 11827)", "species": "Serendipita indica "},
+    "xrefid": "G4TQ79",
+    "sequence_length": 610,
+    "gc_content": 0.5259138025095472,
+    "protid": "SERID07469",
+    "id": 6819581
+  }, {
+    "taxon": {"strain": "", "species": "Agaricus bisporus"},
+    "xrefid": "",
+    "sequence_length": 557,
+    "gc_content": 0.491636798088411,
+    "protid": "AGABI00940",
+    "id": 6824764
+  }, {
+    "taxon": {"strain": "", "species": "Agaricus bisporus"},
+    "xrefid": "",
+    "sequence_length": 609,
+    "gc_content": 0.48032786885245904,
+    "protid": "AGABI08015",
+    "id": 6831839
+  }, {
+    "taxon": {"strain": "", "species": "Coprinopsis cinerea"},
+    "xrefid": "",
+    "sequence_length": 608,
+    "gc_content": 0.5582922824302134,
+    "protid": "COPCI06292",
+    "id": 6840482
+  }, {
+    "taxon": {"strain": "", "species": "Coprinopsis cinerea"},
+    "xrefid": "",
+    "sequence_length": 558,
+    "gc_content": 0.528324388789505,
+    "protid": "COPCI06705",
+    "id": 6840895
+  }, {
+    "taxon": {"strain": "", "species": "Coprinopsis cinerea"},
+    "xrefid": "",
+    "sequence_length": 760,
+    "gc_content": 0.5247481384143671,
+    "protid": "COPCI10725",
+    "id": 6844915
+  }, {
+    "taxon": {"strain": "", "species": "Coprinopsis cinerea"},
+    "xrefid": "",
+    "sequence_length": 697,
+    "gc_content": 0.5592168099331423,
+    "protid": "COPCI15059",
+    "id": 6849249
+  }, {
+    "taxon": {"strain": "", "species": "Schizophyllum commune"},
+    "xrefid": "",
+    "sequence_length": 580,
+    "gc_content": 0.5869191049913941,
+    "protid": "SCHCO06680",
+    "id": 6859791
+  }, {
+    "taxon": {"strain": "", "species": "Schizophyllum commune"},
+    "xrefid": "",
+    "sequence_length": 559,
+    "gc_content": 0.5994047619047619,
+    "protid": "SCHCO11870",
+    "id": 6864981
+  }, {
+    "taxon": {"strain": "", "species": "Laccaria bicolor"},
+    "xrefid": "",
+    "sequence_length": 547,
+    "gc_content": 0.4884428223844282,
+    "protid": "LACBI01220",
+    "id": 6867443
+  }, {
+    "taxon": {"strain": "", "species": "Laccaria bicolor"},
+    "xrefid": "",
+    "sequence_length": 551,
+    "gc_content": 0.48731884057971014,
+    "protid": "LACBI02759",
+    "id": 6868982
+  }, {
+    "taxon": {"strain": "(strain RWD-64-598)", "species": "Coniophora puteana "},
+    "xrefid": "",
+    "sequence_length": 559,
+    "gc_content": 0.5071428571428571,
+    "protid": "CONPW00916",
+    "id": 6887191
+  }, {
+    "taxon": {"strain": "(strain RWD-64-598)", "species": "Coniophora puteana "},
+    "xrefid": "",
+    "sequence_length": 613,
+    "gc_content": 0.5336590662323561,
+    "protid": "CONPW07560",
+    "id": 6893835
+  }, {
+    "taxon": {"strain": "", "species": "Tremella mesenterica"},
+    "xrefid": "",
+    "sequence_length": 552,
+    "gc_content": 0.48764315852923446,
+    "protid": "TREME03901",
+    "id": 6916358
+  }, {
+    "taxon": {"strain": "", "species": "Tremella mesenterica"},
+    "xrefid": "",
+    "sequence_length": 551,
+    "gc_content": 0.47101449275362317,
+    "protid": "TREME05648",
+    "id": 6918105
+  }, {
+    "taxon": {"strain": "", "species": "Wallemia sebi"},
+    "xrefid": "",
+    "sequence_length": 524,
+    "gc_content": 0.4311111111111111,
+    "protid": "WALSE00873",
+    "id": 6921578
+  }, {
+    "taxon": {"strain": "", "species": "Wallemia sebi"},
+    "xrefid": "",
+    "sequence_length": 573,
+    "gc_content": 0.4175377468060395,
+    "protid": "WALSE01217",
+    "id": 6921922
+  }, {
+    "taxon": {"strain": "(strain CBS 9802 / IAM 14324 / JCM 22182 / KY 12970)", "species": "Mixia osmundae "},
+    "xrefid": "G7DVS9",
+    "sequence_length": 539,
+    "gc_content": 0.5302469135802469,
+    "protid": "MIXOS03639",
+    "id": 6929611
+  }, {
+    "taxon": {"strain": "", "species": "Puccinia graminis"},
+    "xrefid": "",
+    "sequence_length": 652,
+    "gc_content": 0.5329249617151608,
+    "protid": "PUCGR05874",
+    "id": 6938629
+  }, {
+    "taxon": {"strain": "", "species": "Puccinia graminis"},
+    "xrefid": "",
+    "sequence_length": 561,
+    "gc_content": 0.4578884934756821,
+    "protid": "PUCGR08253",
+    "id": 6941008
+  }, {
+    "taxon": {"strain": "(strain CRL 75-36-700-3 / race SCCL)", "species": "Puccinia graminis f. sp. tritici "},
+    "xrefid": "E3K1Z5",
+    "sequence_length": 652,
+    "gc_content": 0.5332310838445807,
+    "protid": "PUCGT00820",
+    "id": 6953939
+  }, {
+    "taxon": {"strain": "(strain CRL 75-36-700-3 / race SCCL)", "species": "Puccinia graminis f. sp. tritici "},
+    "xrefid": "",
+    "sequence_length": 561,
+    "gc_content": 0.45870469399881164,
+    "protid": "PUCGT15183",
+    "id": 6968302
+  }, {
+    "taxon": {"strain": "", "species": "Branchiostoma floridae"},
+    "xrefid": "C3ZTT7",
+    "sequence_length": 516,
+    "gc_content": 0.5203094777562862,
+    "protid": "BRAFL07149",
+    "id": 7040620
+  }, {
+    "taxon": {"strain": "", "species": "Branchiostoma floridae"},
+    "xrefid": "C3YPW7",
+    "sequence_length": 612,
+    "gc_content": 0.5666122892876564,
+    "protid": "BRAFL08202",
+    "id": 7041673
+  }, {
+    "taxon": {"strain": "", "species": "Branchiostoma floridae"},
+    "xrefid": "C3XUP1",
+    "sequence_length": 578,
+    "gc_content": 0.5325273459988485,
+    "protid": "BRAFL18907",
+    "id": 7052378
+  }, {
+    "taxon": {"strain": "", "species": "Branchiostoma floridae"},
+    "xrefid": "C3YUJ9",
+    "sequence_length": 546,
+    "gc_content": 0.5051797684338818,
+    "protid": "BRAFL22842",
+    "id": 7056313
+  }, {
+    "taxon": {"strain": "", "species": "Branchiostoma floridae"},
+    "xrefid": "C3XXZ5",
+    "sequence_length": 711,
+    "gc_content": 0.5706928838951311,
+    "protid": "BRAFL25322",
+    "id": 7058793
+  }, {
+    "taxon": {"strain": "", "species": "Petromyzon marinus"},
+    "xrefid": "S4R514",
+    "sequence_length": 685,
+    "gc_content": 0.5975669099756691,
+    "protid": "PETMA07832",
+    "id": 7069767
+  }, {
+    "taxon": {"strain": "", "species": "Lepisosteus oculatus"},
+    "xrefid": "W5NJL6",
+    "sequence_length": 560,
+    "gc_content": 0.5834818775995246,
+    "protid": "LEPOC00878",
+    "id": 7073579
+  }, {
+    "taxon": {"strain": "", "species": "Lepisosteus oculatus"},
+    "xrefid": "W5MMC1",
+    "sequence_length": 567,
+    "gc_content": 0.45422535211267606,
+    "protid": "LEPOC05731",
+    "id": 7078432
+  }, {
+    "taxon": {"strain": "", "species": "Lepisosteus oculatus"},
+    "xrefid": "W5MK19",
+    "sequence_length": 572,
+    "gc_content": 0.44851657940663175,
+    "protid": "LEPOC11231",
+    "id": 7083932
+  }, {
+    "taxon": {"strain": "", "species": "Lepisosteus oculatus"},
+    "xrefid": "W5N9C3",
+    "sequence_length": 777,
+    "gc_content": 0.5646958011996572,
+    "protid": "LEPOC11914",
+    "id": 7084615
+  }, {
+    "taxon": {"strain": "", "species": "Lepisosteus oculatus"},
+    "xrefid": "W5NDX2",
+    "sequence_length": 563,
+    "gc_content": 0.5596926713947991,
+    "protid": "LEPOC16135",
+    "id": 7088836
+  }, {
+    "taxon": {"strain": "", "species": "Gasterosteus aculeatus"},
+    "xrefid": "G3NYG9",
+    "sequence_length": 752,
+    "gc_content": 0.5595396193005755,
+    "protid": "GASAC15418",
+    "id": 7107012
+  }, {
+    "taxon": {"strain": "", "species": "Gasterosteus aculeatus"},
+    "xrefid": "G3PSC4",
+    "sequence_length": 565,
+    "gc_content": 0.6177856301531213,
+    "protid": "GASAC20475",
+    "id": 7112069
+  }, {
+    "taxon": {"strain": "", "species": "Gasterosteus aculeatus"},
+    "xrefid": "G3PZ36",
+    "sequence_length": 561,
+    "gc_content": 0.5468564650059312,
+    "protid": "GASAC20752",
+    "id": 7112346
+  }, {
+    "taxon": {"strain": "", "species": "Takifugu rubripes"},
+    "xrefid": "H2S6G6",
+    "sequence_length": 571,
+    "gc_content": 0.5407925407925408,
+    "protid": "TAKRU01668",
+    "id": 7115035
+  }, {
+    "taxon": {"strain": "", "species": "Takifugu rubripes"},
+    "xrefid": "H2T6E0",
+    "sequence_length": 593,
+    "gc_content": 0.46936481169196176,
+    "protid": "TAKRU08644",
+    "id": 7122011
+  }, {
+    "taxon": {"strain": "", "species": "Takifugu rubripes"},
+    "xrefid": "H2U8C1",
+    "sequence_length": 746,
+    "gc_content": 0.5269968763944668,
+    "protid": "TAKRU11762",
+    "id": 7125129
+  }, {
+    "taxon": {"strain": "", "species": "Takifugu rubripes"},
+    "xrefid": "Q7T1Q1",
+    "sequence_length": 565,
+    "gc_content": 0.5606595995288575,
+    "protid": "TAKRU15294",
+    "id": 7128661
+  }, {
+    "taxon": {"strain": "", "species": "Tetraodon nigroviridis"},
+    "xrefid": "H3DHH8",
+    "sequence_length": 566,
+    "gc_content": 0.5508524397413286,
+    "protid": "TETNG00443",
+    "id": 7136752
+  }, {
+    "taxon": {"strain": "", "species": "Tetraodon nigroviridis"},
+    "xrefid": "Q4SEQ8",
+    "sequence_length": 565,
+    "gc_content": 0.6124852767962309,
+    "protid": "TETNG09492",
+    "id": 7145801
+  }, {
+    "taxon": {"strain": "", "species": "Tetraodon nigroviridis"},
+    "xrefid": "Q4TGY3",
+    "sequence_length": 592,
+    "gc_content": 0.6188063063063063,
+    "protid": "TETNG16987",
+    "id": 7153296
+  }, {
+    "taxon": {"strain": "", "species": "Oryzias latipes"},
+    "xrefid": "H2L7D0",
+    "sequence_length": 565,
+    "gc_content": 0.5058892815076561,
+    "protid": "ORYLA00988",
+    "id": 7157317
+  }, {
+    "taxon": {"strain": "", "species": "Oryzias latipes"},
+    "xrefid": "H2M5R8",
+    "sequence_length": 575,
+    "gc_content": 0.4973913043478261,
+    "protid": "ORYLA03586",
+    "id": 7159915
+  }, {
+    "taxon": {"strain": "", "species": "Oryzias latipes"},
+    "xrefid": "H2L879",
+    "sequence_length": 566,
+    "gc_content": 0.5161669606114051,
+    "protid": "ORYLA08554",
+    "id": 7164883
+  }, {
+    "taxon": {"strain": "", "species": "Oryzias latipes"},
+    "xrefid": "H2MGC7",
+    "sequence_length": 752,
+    "gc_content": 0.5179282868525896,
+    "protid": "ORYLA15210",
+    "id": 7171539
+  }, {
+    "taxon": {"strain": "", "species": "Poecilia formosa"},
+    "xrefid": "A0A087XPB4",
+    "sequence_length": 561,
+    "gc_content": 0.5207591933570581,
+    "protid": "POEFO12861",
+    "id": 7189689
+  }, {
+    "taxon": {"strain": "", "species": "Poecilia formosa"},
+    "xrefid": "A0A087Y4W7",
+    "sequence_length": 783,
+    "gc_content": 0.5471938775510204,
+    "protid": "POEFO14948",
+    "id": 7191776
+  }, {
+    "taxon": {"strain": "", "species": "Poecilia formosa"},
+    "xrefid": "A0A087YFK7",
+    "sequence_length": 572,
+    "gc_content": 0.5381035485747527,
+    "protid": "POEFO16047",
+    "id": 7192875
+  }, {
+    "taxon": {"strain": "", "species": "Poecilia formosa"},
+    "xrefid": "A0A087YJ63",
+    "sequence_length": 566,
+    "gc_content": 0.5955320399764844,
+    "protid": "POEFO18951",
+    "id": 7195779
+  }, {
+    "taxon": {"strain": "", "species": "Xiphophorus maculatus"},
+    "xrefid": "M3ZW19",
+    "sequence_length": 565,
+    "gc_content": 0.6060070671378092,
+    "protid": "XIPMA05166",
+    "id": 7207157
+  }, {
+    "taxon": {"strain": "", "species": "Xiphophorus maculatus"},
+    "xrefid": "M4A9T6",
+    "sequence_length": 559,
+    "gc_content": 0.5071428571428571,
+    "protid": "XIPMA12502",
+    "id": 7214493
+  }, {
+    "taxon": {"strain": "", "species": "Xiphophorus maculatus"},
+    "xrefid": "M4AGE9",
+    "sequence_length": 583,
+    "gc_content": 0.53824200913242,
+    "protid": "XIPMA16033",
+    "id": 7218024
+  }, {
+    "taxon": {"strain": "", "species": "Xiphophorus maculatus"},
+    "xrefid": "M3ZX41",
+    "sequence_length": 783,
+    "gc_content": 0.5501700680272109,
+    "protid": "XIPMA19241",
+    "id": 7221232
+  }, {
+    "taxon": {"strain": "", "species": "Oreochromis niloticus"},
+    "xrefid": "I3J362",
+    "sequence_length": 570,
+    "gc_content": 0.506713368359603,
+    "protid": "ORENI01890",
+    "id": 7224251
+  }, {
+    "taxon": {"strain": "", "species": "Oreochromis niloticus"},
+    "xrefid": "I3JC79",
+    "sequence_length": 576,
+    "gc_content": 0.5054881571346043,
+    "protid": "ORENI10637",
+    "id": 7232998
+  }, {
+    "taxon": {"strain": "", "species": "Oreochromis niloticus"},
+    "xrefid": "I3J6V9",
+    "sequence_length": 565,
+    "gc_content": 0.5117785630153121,
+    "protid": "ORENI11210",
+    "id": 7233571
+  }, {
+    "taxon": {"strain": "", "species": "Oreochromis niloticus"},
+    "xrefid": "I3KPB6",
+    "sequence_length": 747,
+    "gc_content": 0.5601604278074866,
+    "protid": "ORENI18451",
+    "id": 7240812
+  }, {
+    "taxon": {"strain": "", "species": "Gadus morhua"},
+    "xrefid": "ENSGMOG00000001828",
+    "sequence_length": 688,
+    "gc_content": 0.6038929440389295,
+    "protid": "GADMO01548",
+    "id": 7246166
+  }, {
+    "taxon": {"strain": "", "species": "Gadus morhua"},
+    "xrefid": "ENSGMOG00000004641",
+    "sequence_length": 565,
+    "gc_content": 0.591283863368669,
+    "protid": "GADMO08144",
+    "id": 7252762
+  }, {
+    "taxon": {"strain": "", "species": "Gadus morhua"},
+    "xrefid": "ENSGMOG00000005121",
+    "sequence_length": 562,
+    "gc_content": 0.5249110320284698,
+    "protid": "GADMO20376",
+    "id": 7264994
+  }, {
+    "taxon": {"strain": "", "species": "Astyanax mexicanus"},
+    "xrefid": "W5LF28",
+    "sequence_length": 895,
+    "gc_content": 0.47470238095238093,
+    "protid": "ASTMX02214",
+    "id": 7267311
+  }, {
+    "taxon": {"strain": "", "species": "Astyanax mexicanus"},
+    "xrefid": "W5LQ45",
+    "sequence_length": 576,
+    "gc_content": 0.5049104563835933,
+    "protid": "ASTMX04520",
+    "id": 7269617
+  }, {
+    "taxon": {"strain": "", "species": "Astyanax mexicanus"},
+    "xrefid": "W5K8U1",
+    "sequence_length": 571,
+    "gc_content": 0.5011655011655012,
+    "protid": "ASTMX05855",
+    "id": 7270952
+  }, {
+    "taxon": {"strain": "", "species": "Astyanax mexicanus"},
+    "xrefid": "W5KMR9",
+    "sequence_length": 567,
+    "gc_content": 0.5064553990610329,
+    "protid": "ASTMX11852",
+    "id": 7276949
+  }, {
+    "taxon": {"strain": "", "species": "Danio rerio"},
+    "xrefid": "F1QV52",
+    "sequence_length": 565,
+    "gc_content": 0.4840989399293286,
+    "protid": "DANRE02538",
+    "id": 7290714
+  }, {
+    "taxon": {"strain": "", "species": "Danio rerio"},
+    "xrefid": "F6NMX7",
+    "sequence_length": 564,
+    "gc_content": 0.48908554572271384,
+    "protid": "DANRE07165",
+    "id": 7295341
+  }, {
+    "taxon": {"strain": "", "species": "Danio rerio"},
+    "xrefid": "E7F9M1",
+    "sequence_length": 718,
+    "gc_content": 0.5006954102920723,
+    "protid": "DANRE25219",
+    "id": 7313395
+  }, {
+    "taxon": {"strain": "", "species": "Latimeria chalumnae"},
+    "xrefid": "H3A6K7",
+    "sequence_length": 567,
+    "gc_content": 0.43133802816901406,
+    "protid": "LATCH03346",
+    "id": 7334963
+  }, {
+    "taxon": {"strain": "", "species": "Latimeria chalumnae"},
+    "xrefid": "H3AJ35",
+    "sequence_length": 568,
+    "gc_content": 0.44698301113063854,
+    "protid": "LATCH04569",
+    "id": 7336186
+  }, {
+    "taxon": {"strain": "", "species": "Latimeria chalumnae"},
+    "xrefid": "H3B1H0",
+    "sequence_length": 939,
+    "gc_content": 0.38049645390070924,
+    "protid": "LATCH12816",
+    "id": 7344433
+  }, {
+    "taxon": {"strain": "", "species": "Latimeria chalumnae"},
+    "xrefid": "H3AQA5",
+    "sequence_length": 541,
+    "gc_content": 0.4011090573012939,
+    "protid": "LATCH13453",
+    "id": 7345070
+  }, {
+    "taxon": {"strain": "", "species": "Latimeria chalumnae"},
+    "xrefid": "H3B8N6",
+    "sequence_length": 567,
+    "gc_content": 0.47417840375586856,
+    "protid": "LATCH16376",
+    "id": 7347993
+  }, {
+    "taxon": {"strain": "", "species": "Ornithorhynchus anatinus"},
+    "xrefid": "ENSOANG00000007111",
+    "sequence_length": 573,
+    "gc_content": 0.4843205574912892,
+    "protid": "ORNAN03142",
+    "id": 7355117
+  }, {
+    "taxon": {"strain": "", "species": "Ornithorhynchus anatinus"},
+    "xrefid": "F6V9B5",
+    "sequence_length": 844,
+    "gc_content": 0.6185404339250493,
+    "protid": "ORNAN13295",
+    "id": 7365270
+  }, {
+    "taxon": {"strain": "", "species": "Ornithorhynchus anatinus"},
+    "xrefid": "F7FMH2",
+    "sequence_length": 659,
+    "gc_content": 0.6064744562468386,
+    "protid": "ORNAN15123",
+    "id": 7367098
+  }, {
+    "taxon": {"strain": "", "species": "Ornithorhynchus anatinus"},
+    "xrefid": "ENSOANG00000008867",
+    "sequence_length": 547,
+    "gc_content": 0.44038929440389296,
+    "protid": "ORNAN18952",
+    "id": 7370927
+  }, {
+    "taxon": {"strain": "", "species": "Procavia capensis"},
+    "xrefid": "ENSPCAG00000013333",
+    "sequence_length": 453,
+    "gc_content": 0.4830383480825959,
+    "protid": "PROCA04768",
+    "id": 7376473
+  }, {
+    "taxon": {"strain": "", "species": "Procavia capensis"},
+    "xrefid": "ENSPCAG00000013836",
+    "sequence_length": 471,
+    "gc_content": 0.4989384288747346,
+    "protid": "PROCA09813",
+    "id": 7381518
+  }, {
+    "taxon": {"strain": "", "species": "Procavia capensis"},
+    "xrefid": "ENSPCAG00000005212",
+    "sequence_length": 272,
+    "gc_content": 0.44582814445828145,
+    "protid": "PROCA11613",
+    "id": 7383318
+  }, {
+    "taxon": {"strain": "", "species": "Loxodonta africana"},
+    "xrefid": "G3T9Q8",
+    "sequence_length": 571,
+    "gc_content": 0.4784382284382284,
+    "protid": "LOXAF01875",
+    "id": 7389582
+  }, {
+    "taxon": {"strain": "", "species": "Loxodonta africana"},
+    "xrefid": "G3THC6",
+    "sequence_length": 579,
+    "gc_content": 0.43448275862068964,
+    "protid": "LOXAF05772",
+    "id": 7393479
+  }, {
+    "taxon": {"strain": "", "species": "Loxodonta africana"},
+    "xrefid": "G3TBF7",
+    "sequence_length": 572,
+    "gc_content": 0.4851657940663176,
+    "protid": "LOXAF20450",
+    "id": 7408157
+  }, {
+    "taxon": {"strain": "", "species": "Echinops telfairi"},
+    "xrefid": "ENSETEG00000003927",
+    "sequence_length": 569,
+    "gc_content": 0.4608187134502924,
+    "protid": "ECHTE09769",
+    "id": 7418526
+  }, {
+    "taxon": {"strain": "", "species": "Echinops telfairi"},
+    "xrefid": "ENSETEG00000018581",
+    "sequence_length": 376,
+    "gc_content": 0.44928825622775803,
+    "protid": "ECHTE14431",
+    "id": 7423188
+  }, {
+    "taxon": {"strain": "", "species": "Echinops telfairi"},
+    "xrefid": "ENSETEG00000005714",
+    "sequence_length": 431,
+    "gc_content": 0.524551831644583,
+    "protid": "ECHTE16189",
+    "id": 7424946
+  }, {
+    "taxon": {"strain": "", "species": "Oryctolagus cuniculus"},
+    "xrefid": "G1TC62",
+    "sequence_length": 530,
+    "gc_content": 0.42623979912115506,
+    "protid": "RABIT00736",
+    "id": 7425992
+  }, {
+    "taxon": {"strain": "", "species": "Oryctolagus cuniculus"},
+    "xrefid": "G1SFF8",
+    "sequence_length": 571,
+    "gc_content": 0.5064102564102564,
+    "protid": "RABIT02942",
+    "id": 7428198
+  }, {
+    "taxon": {"strain": "", "species": "Oryctolagus cuniculus"},
+    "xrefid": "G1TE14",
+    "sequence_length": 735,
+    "gc_content": 0.508843537414966,
+    "protid": "RABIT13407",
+    "id": 7438663
+  }, {
+    "taxon": {"strain": "", "species": "Oryctolagus cuniculus"},
+    "xrefid": "G1SPD7",
+    "sequence_length": 564,
+    "gc_content": 0.4713864306784661,
+    "protid": "RABIT13828",
+    "id": 7439084
+  }, {
+    "taxon": {"strain": "", "species": "Oryctolagus cuniculus"},
+    "xrefid": "G1TA91",
+    "sequence_length": 800,
+    "gc_content": 0.6329588014981273,
+    "protid": "RABIT16316",
+    "id": 7441572
+  }, {
+    "taxon": {"strain": "", "species": "Ochotona princeps"},
+    "xrefid": "ENSOPRG00000007131",
+    "sequence_length": 398,
+    "gc_content": 0.44839255499153974,
+    "protid": "OCHPR04411",
+    "id": 7449034
+  }, {
+    "taxon": {"strain": "", "species": "Ochotona princeps"},
+    "xrefid": "ENSOPRG00000008949",
+    "sequence_length": 473,
+    "gc_content": 0.4964689265536723,
+    "protid": "OCHPR11357",
+    "id": 7455980
+  }, {
+    "taxon": {"strain": "", "species": "Dipodomys ordii"},
+    "xrefid": "ENSDORG00000007197",
+    "sequence_length": 496,
+    "gc_content": 0.4415322580645161,
+    "protid": "DIPOR07252",
+    "id": 7467743
+  }, {
+    "taxon": {"strain": "", "species": "Dipodomys ordii"},
+    "xrefid": "ENSDORG00000012634",
+    "sequence_length": 513,
+    "gc_content": 0.45289148797920725,
+    "protid": "DIPOR09370",
+    "id": 7469861
+  }, {
+    "taxon": {"strain": "", "species": "Dipodomys ordii"},
+    "xrefid": "ENSDORG00000009803",
+    "sequence_length": 565,
+    "gc_content": 0.4929328621908127,
+    "protid": "DIPOR10466",
+    "id": 7470957
+  }, {
+    "taxon": {"strain": "", "species": "Dipodomys ordii"},
+    "xrefid": "ENSDORG00000002351",
+    "sequence_length": 529,
+    "gc_content": 0.4421983575489577,
+    "protid": "DIPOR14398",
+    "id": 7474889
+  }, {
+    "taxon": {"strain": "", "species": "Cavia porcellus"},
+    "xrefid": "ENSCPOG00000001003",
+    "sequence_length": 572,
+    "gc_content": 0.4813519813519814,
+    "protid": "CAVPO07652",
+    "id": 7483861
+  }, {
+    "taxon": {"strain": "", "species": "Cavia porcellus"},
+    "xrefid": "H0UXC6",
+    "sequence_length": 570,
+    "gc_content": 0.4500875656742557,
+    "protid": "CAVPO08522",
+    "id": 7484731
+  }, {
+    "taxon": {"strain": "", "species": "Cavia porcellus"},
+    "xrefid": "A0A286XFC6",
+    "sequence_length": 564,
+    "gc_content": 0.4471976401179941,
+    "protid": "CAVPO10456",
+    "id": 7486665
+  }, {
+    "taxon": {"strain": "", "species": "Mus musculus"},
+    "xrefid": "NOX3_MOUSE",
+    "sequence_length": 568,
+    "gc_content": 0.4961921499707089,
+    "protid": "MOUSE09440",
+    "id": 7504589
+  }, {
+    "taxon": {"strain": "", "species": "Mus musculus"},
+    "xrefid": "NOX4_MOUSE",
+    "sequence_length": 592,
+    "gc_content": 0.4300168634064081,
+    "protid": "MOUSE21512",
+    "id": 7516661
+  }, {
+    "taxon": {"strain": "", "species": "Mus musculus"},
+    "xrefid": "CY24B_MOUSE",
+    "sequence_length": 570,
+    "gc_content": 0.4746059544658494,
+    "protid": "MOUSE25484",
+    "id": 7520633
+  }, {
+    "taxon": {"strain": "", "species": "Mus musculus"},
+    "xrefid": "NOX1_MOUSE",
+    "sequence_length": 563,
+    "gc_content": 0.4627659574468085,
+    "protid": "MOUSE26167",
+    "id": 7521316
+  }, {
+    "taxon": {"strain": "", "species": "Rattus norvegicus"},
+    "xrefid": "NOX3_RAT",
+    "sequence_length": 568,
+    "gc_content": 0.4991212653778559,
+    "protid": "RATNO00238",
+    "id": 7522106
+  }, {
+    "taxon": {"strain": "", "species": "Rattus norvegicus"},
+    "xrefid": "NOX4_RAT",
+    "sequence_length": 578,
+    "gc_content": 0.4369602763385147,
+    "protid": "RATNO01399",
+    "id": 7523267
+  }, {
+    "taxon": {"strain": "", "species": "Rattus norvegicus"},
+    "xrefid": "Q9ERL1",
+    "sequence_length": 570,
+    "gc_content": 0.475189725627554,
+    "protid": "RATNO21413",
+    "id": 7543281
+  }, {
+    "taxon": {"strain": "", "species": "Rattus norvegicus"},
+    "xrefid": "M0R934",
+    "sequence_length": 563,
+    "gc_content": 0.46631205673758863,
+    "protid": "RATNO21837",
+    "id": 7543705
+  }, {
+    "taxon": {"strain": "", "species": "Ictidomys tridecemlineatus"},
+    "xrefid": "ENSSTOG00000005122",
+    "sequence_length": 574,
+    "gc_content": 0.4535423925667828,
+    "protid": "ICTTR00166",
+    "id": 7544396
+  }, {
+    "taxon": {"strain": "", "species": "Ictidomys tridecemlineatus"},
+    "xrefid": "ENSSTOG00000008210",
+    "sequence_length": 358,
+    "gc_content": 0.43109869646182497,
+    "protid": "ICTTR11242",
+    "id": 7555472
+  }, {
+    "taxon": {"strain": "", "species": "Ictidomys tridecemlineatus"},
+    "xrefid": "ENSSTOG00000006635",
+    "sequence_length": 760,
+    "gc_content": 0.5764345159877354,
+    "protid": "ICTTR13130",
+    "id": 7557360
+  }, {
+    "taxon": {"strain": "", "species": "Ictidomys tridecemlineatus"},
+    "xrefid": "ENSSTOG00000019548",
+    "sequence_length": 463,
+    "gc_content": 0.47413793103448276,
+    "protid": "ICTTR14582",
+    "id": 7558812
+  }, {
+    "taxon": {"strain": "", "species": "Ictidomys tridecemlineatus"},
+    "xrefid": "ENSSTOG00000000798",
+    "sequence_length": 573,
+    "gc_content": 0.5139372822299652,
+    "protid": "ICTTR18428",
+    "id": 7562658
+  }, {
+    "taxon": {"strain": "", "species": "Chlorocebus sabaeus"},
+    "xrefid": "A0A0D9S0R4",
+    "sequence_length": 578,
+    "gc_content": 0.42487046632124353,
+    "protid": "CHLSB00878",
+    "id": 7564147
+  }, {
+    "taxon": {"strain": "", "species": "Chlorocebus sabaeus"},
+    "xrefid": "A0A0D9RLB9",
+    "sequence_length": 568,
+    "gc_content": 0.4985354422964265,
+    "protid": "CHLSB03869",
+    "id": 7567138
+  }, {
+    "taxon": {"strain": "", "species": "Chlorocebus sabaeus"},
+    "xrefid": "A0A0D9RM64",
+    "sequence_length": 765,
+    "gc_content": 0.5822454308093995,
+    "protid": "CHLSB12523",
+    "id": 7575792
+  }, {
+    "taxon": {"strain": "", "species": "Chlorocebus sabaeus"},
+    "xrefid": "A0A0D9RD63",
+    "sequence_length": 564,
+    "gc_content": 0.4648967551622419,
+    "protid": "CHLSB18649",
+    "id": 7581918
+  }, {
+    "taxon": {"strain": "", "species": "Chlorocebus sabaeus"},
+    "xrefid": "A0A0D9RZN0",
+    "sequence_length": 570,
+    "gc_content": 0.47402218330414475,
+    "protid": "CHLSB19041",
+    "id": 7582310
+  }, {
+    "taxon": {"strain": "", "species": "Macaca mulatta"},
+    "xrefid": "F6TZ83",
+    "sequence_length": 578,
+    "gc_content": 0.4254461715601612,
+    "protid": "MACMU07739",
+    "id": 7590180
+  }, {
+    "taxon": {"strain": "", "species": "Macaca mulatta"},
+    "xrefid": "F7DQ72",
+    "sequence_length": 568,
+    "gc_content": 0.4985354422964265,
+    "protid": "MACMU17112",
+    "id": 7599553
+  }, {
+    "taxon": {"strain": "", "species": "Macaca mulatta"},
+    "xrefid": "ENSMMUG00000006230",
+    "sequence_length": 766,
+    "gc_content": 0.576271186440678,
+    "protid": "MACMU19828",
+    "id": 7602269
+  }, {
+    "taxon": {"strain": "", "species": "Macaca mulatta"},
+    "xrefid": "F6X7S5",
+    "sequence_length": 570,
+    "gc_content": 0.47869235259778165,
+    "protid": "MACMU22997",
+    "id": 7605438
+  }, {
+    "taxon": {"strain": "", "species": "Macaca mulatta"},
+    "xrefid": "F6X2U4",
+    "sequence_length": 564,
+    "gc_content": 0.46607669616519176,
+    "protid": "MACMU23394",
+    "id": 7605835
+  }, {
+    "taxon": {"strain": "", "species": "Papio anubis"},
+    "xrefid": "A0A096MLX2",
+    "sequence_length": 579,
+    "gc_content": 0.42528735632183906,
+    "protid": "PAPAN06091",
+    "id": 7613302
+  }, {
+    "taxon": {"strain": "", "species": "Papio anubis"},
+    "xrefid": "A0A096NF43",
+    "sequence_length": 571,
+    "gc_content": 0.4976689976689977,
+    "protid": "PAPAN13591",
+    "id": 7620802
+  }, {
+    "taxon": {"strain": "", "species": "Papio anubis"},
+    "xrefid": "A0A096NMI8",
+    "sequence_length": 765,
+    "gc_content": 0.5848563968668408,
+    "protid": "PAPAN15711",
+    "id": 7622922
+  }, {
+    "taxon": {"strain": "", "species": "Papio anubis"},
+    "xrefid": "A0A096MRV2",
+    "sequence_length": 573,
+    "gc_content": 0.4721254355400697,
+    "protid": "PAPAN18119",
+    "id": 7625330
+  }, {
+    "taxon": {"strain": "", "species": "Papio anubis"},
+    "xrefid": "A0A096MKS0",
+    "sequence_length": 564,
+    "gc_content": 0.4672566371681416,
+    "protid": "PAPAN18394",
+    "id": 7625605
+  }, {
+    "taxon": {"strain": "", "species": "Gorilla gorilla gorilla"},
+    "xrefid": "G3QL27",
+    "sequence_length": 433,
+    "gc_content": 0.43648960739030024,
+    "protid": "GORGO04034",
+    "id": 7630574
+  }, {
+    "taxon": {"strain": "", "species": "Gorilla gorilla gorilla"},
+    "xrefid": "G3R3J0",
+    "sequence_length": 767,
+    "gc_content": 0.5872395833333334,
+    "protid": "GORGO06980",
+    "id": 7633520
+  }, {
+    "taxon": {"strain": "", "species": "Gorilla gorilla gorilla"},
+    "xrefid": "G3RI51",
+    "sequence_length": 570,
+    "gc_content": 0.4979568009340339,
+    "protid": "GORGO18086",
+    "id": 7644626
+  }, {
+    "taxon": {"strain": "", "species": "Gorilla gorilla gorilla"},
+    "xrefid": "G3QXY3",
+    "sequence_length": 570,
+    "gc_content": 0.4705195563339171,
+    "protid": "GORGO21090",
+    "id": 7647630
+  }, {
+    "taxon": {"strain": "", "species": "Gorilla gorilla gorilla"},
+    "xrefid": "G3QVH2",
+    "sequence_length": 564,
+    "gc_content": 0.46843657817109147,
+    "protid": "GORGO21406",
+    "id": 7647946
+  }, {
+    "taxon": {"strain": "", "species": "Homo sapiens"},
+    "xrefid": "NOX4_HUMAN",
+    "sequence_length": 578,
+    "gc_content": 0.4289004029936672,
+    "protid": "HUMAN05320",
+    "id": 7653682
+  }, {
+    "taxon": {"strain": "", "species": "Homo sapiens"},
+    "xrefid": "NOX5_HUMAN",
+    "sequence_length": 765,
+    "gc_content": 0.5861618798955613,
+    "protid": "HUMAN09709",
+    "id": 7658071
+  }, {
+    "taxon": {"strain": "", "species": "Homo sapiens"},
+    "xrefid": "NOX3_HUMAN",
+    "sequence_length": 568,
+    "gc_content": 0.4997070884592853,
+    "protid": "HUMAN25768",
+    "id": 7674130
+  }, {
+    "taxon": {"strain": "", "species": "Homo sapiens"},
+    "xrefid": "CY24B_HUMAN",
+    "sequence_length": 570,
+    "gc_content": 0.4711033274956217,
+    "protid": "HUMAN29728",
+    "id": 7678090
+  }, {
+    "taxon": {"strain": "", "species": "Homo sapiens"},
+    "xrefid": "NOX1_HUMAN",
+    "sequence_length": 564,
+    "gc_content": 0.46843657817109147,
+    "protid": "HUMAN30115",
+    "id": 7678477
+  }, {
+    "taxon": {"strain": "", "species": "Pan troglodytes"},
+    "xrefid": "H2R516",
+    "sequence_length": 578,
+    "gc_content": 0.4254461715601612,
+    "protid": "PANTR03365",
+    "id": 7682436
+  }, {
+    "taxon": {"strain": "", "species": "Pan troglodytes"},
+    "xrefid": "H2R8B3",
+    "sequence_length": 764,
+    "gc_content": 0.5851851851851851,
+    "protid": "PANTR05857",
+    "id": 7684928
+  }, {
+    "taxon": {"strain": "", "species": "Pan troglodytes"},
+    "xrefid": "H2QTY3",
+    "sequence_length": 568,
+    "gc_content": 0.5032220269478618,
+    "protid": "PANTR15391",
+    "id": 7694462
+  }, {
+    "taxon": {"strain": "", "species": "Pan troglodytes"},
+    "xrefid": "H2R4R9",
+    "sequence_length": 570,
+    "gc_content": 0.47168709865732633,
+    "protid": "PANTR17867",
+    "id": 7696938
+  }, {
+    "taxon": {"strain": "", "species": "Pongo abelii"},
+    "xrefid": "NOX4_PONAB",
+    "sequence_length": 578,
+    "gc_content": 0.4283246977547496,
+    "protid": "PONAB01605",
+    "id": 7699612
+  }, {
+    "taxon": {"strain": "", "species": "Pongo abelii"},
+    "xrefid": "H2NNL6",
+    "sequence_length": 763,
+    "gc_content": 0.5837696335078534,
+    "protid": "PONAB04279",
+    "id": 7702286
+  }, {
+    "taxon": {"strain": "", "species": "Pongo abelii"},
+    "xrefid": "H2PKP7",
+    "sequence_length": 513,
+    "gc_content": 0.4876783398184176,
+    "protid": "PONAB13866",
+    "id": 7711873
+  }, {
+    "taxon": {"strain": "", "species": "Pongo abelii"},
+    "xrefid": "H2PVA4",
+    "sequence_length": 570,
+    "gc_content": 0.4705195563339171,
+    "protid": "PONAB16715",
+    "id": 7714722
+  }, {
+    "taxon": {"strain": "", "species": "Pongo abelii"},
+    "xrefid": "H2PW88",
+    "sequence_length": 522,
+    "gc_content": 0.46335245379222434,
+    "protid": "PONAB17009",
+    "id": 7715016
+  }, {
+    "taxon": {"strain": "", "species": "Nomascus leucogenys"},
+    "xrefid": "G1S1V1",
+    "sequence_length": 599,
+    "gc_content": 0.41944444444444445,
+    "protid": "NOMLE01296",
+    "id": 7717723
+  }, {
+    "taxon": {"strain": "", "species": "Nomascus leucogenys"},
+    "xrefid": "G1S0E9",
+    "sequence_length": 568,
+    "gc_content": 0.4979496192149971,
+    "protid": "NOMLE02170",
+    "id": 7718597
+  }, {
+    "taxon": {"strain": "", "species": "Nomascus leucogenys"},
+    "xrefid": "ENSNLEG00000013408",
+    "sequence_length": 753,
+    "gc_content": 0.5874280655157149,
+    "protid": "NOMLE08551",
+    "id": 7724978
+  }, {
+    "taxon": {"strain": "", "species": "Nomascus leucogenys"},
+    "xrefid": "G1QJQ1",
+    "sequence_length": 570,
+    "gc_content": 0.47168709865732633,
+    "protid": "NOMLE10380",
+    "id": 7726807
+  }, {
+    "taxon": {"strain": "", "species": "Nomascus leucogenys"},
+    "xrefid": "G1R7G9",
+    "sequence_length": 564,
+    "gc_content": 0.4648967551622419,
+    "protid": "NOMLE14417",
+    "id": 7730844
+  }, {
+    "taxon": {"strain": "", "species": "Callithrix jacchus"},
+    "xrefid": "F7DSZ8",
+    "sequence_length": 480,
+    "gc_content": 0.6,
+    "protid": "CALJA01738",
+    "id": 7736882
+  }, {
+    "taxon": {"strain": "", "species": "Callithrix jacchus"},
+    "xrefid": "F7CF27",
+    "sequence_length": 579,
+    "gc_content": 0.4304597701149425,
+    "protid": "CALJA03220",
+    "id": 7738364
+  }, {
+    "taxon": {"strain": "", "species": "Callithrix jacchus"},
+    "xrefid": "F7ICX1",
+    "sequence_length": 568,
+    "gc_content": 0.5073227885178676,
+    "protid": "CALJA15527",
+    "id": 7750671
+  }, {
+    "taxon": {"strain": "", "species": "Callithrix jacchus"},
+    "xrefid": "F7GMR1",
+    "sequence_length": 570,
+    "gc_content": 0.47168709865732633,
+    "protid": "CALJA22257",
+    "id": 7757401
+  }, {
+    "taxon": {"strain": "", "species": "Callithrix jacchus"},
+    "xrefid": "F7IAY7",
+    "sequence_length": 564,
+    "gc_content": 0.4584070796460177,
+    "protid": "CALJA22604",
+    "id": 7757748
+  }, {
+    "taxon": {"strain": "", "species": "Tarsius syrichta"},
+    "xrefid": "ENSTSYG00000006638",
+    "sequence_length": 562,
+    "gc_content": 0.45944345766725875,
+    "protid": "TARSY09417",
+    "id": 7768559
+  }, {
+    "taxon": {"strain": "", "species": "Tarsius syrichta"},
+    "xrefid": "A0A1U7TY31",
+    "sequence_length": 570,
+    "gc_content": 0.46351430239346175,
+    "protid": "TARSY09884",
+    "id": 7769026
+  }, {
+    "taxon": {"strain": "", "species": "Tarsius syrichta"},
+    "xrefid": "ENSTSYG00000011853",
+    "sequence_length": 412,
+    "gc_content": 0.41038118410381186,
+    "protid": "TARSY11255",
+    "id": 7770397
+  }, {
+    "taxon": {"strain": "", "species": "Tarsius syrichta"},
+    "xrefid": "ENSTSYG00000007685",
+    "sequence_length": 496,
+    "gc_content": 0.48215488215488217,
+    "protid": "TARSY11348",
+    "id": 7770490
+  }, {
+    "taxon": {"strain": "", "species": "Microcebus murinus"},
+    "xrefid": "ENSMICG00000014139",
+    "sequence_length": 349,
+    "gc_content": 0.4875478927203065,
+    "protid": "MICMU06885",
+    "id": 7779582
+  }, {
+    "taxon": {"strain": "", "species": "Microcebus murinus"},
+    "xrefid": "ENSMICG00000011586",
+    "sequence_length": 515,
+    "gc_content": 0.500324464633355,
+    "protid": "MICMU13754",
+    "id": 7786451
+  }, {
+    "taxon": {"strain": "", "species": "Otolemur garnettii"},
+    "xrefid": "H0X390",
+    "sequence_length": 571,
+    "gc_content": 0.46503496503496505,
+    "protid": "OTOGA03489",
+    "id": 7792409
+  }, {
+    "taxon": {"strain": "", "species": "Otolemur garnettii"},
+    "xrefid": "H0X303",
+    "sequence_length": 568,
+    "gc_content": 0.5090802577621558,
+    "protid": "OTOGA05221",
+    "id": 7794141
+  }, {
+    "taxon": {"strain": "", "species": "Otolemur garnettii"},
+    "xrefid": "H0X4B6",
+    "sequence_length": 586,
+    "gc_content": 0.46507666098807493,
+    "protid": "OTOGA05272",
+    "id": 7794192
+  }, {
+    "taxon": {"strain": "", "species": "Otolemur garnettii"},
+    "xrefid": "H0X6I4",
+    "sequence_length": 603,
+    "gc_content": 0.4034216335540839,
+    "protid": "OTOGA18919",
+    "id": 7807839
+  }, {
+    "taxon": {"strain": "", "species": "Tupaia belangeri"},
+    "xrefid": "ENSTBEG00000011963",
+    "sequence_length": 559,
+    "gc_content": 0.48985680190930786,
+    "protid": "TUPBE06374",
+    "id": 7814808
+  }, {
+    "taxon": {"strain": "", "species": "Tupaia belangeri"},
+    "xrefid": "ENSTBEG00000010657",
+    "sequence_length": 379,
+    "gc_content": 0.4438549955791335,
+    "protid": "TUPBE07339",
+    "id": 7815773
+  }, {
+    "taxon": {"strain": "", "species": "Tupaia belangeri"},
+    "xrefid": "ENSTBEG00000014542",
+    "sequence_length": 534,
+    "gc_content": 0.4681647940074906,
+    "protid": "TUPBE07626",
+    "id": 7816060
+  }, {
+    "taxon": {"strain": "", "species": "Tupaia belangeri"},
+    "xrefid": "ENSTBEG00000004478",
+    "sequence_length": 542,
+    "gc_content": 0.43050430504305043,
+    "protid": "TUPBE10407",
+    "id": 7818841
+  }, {
+    "taxon": {"strain": "", "species": "Canis lupus familiaris"},
+    "xrefid": "F1PBK1",
+    "sequence_length": 573,
+    "gc_content": 0.483739837398374,
+    "protid": "CANLF00231",
+    "id": 7824038
+  }, {
+    "taxon": {"strain": "", "species": "Canis lupus familiaris"},
+    "xrefid": "F1PSM8",
+    "sequence_length": 606,
+    "gc_content": 0.42613948380010985,
+    "protid": "CANLF08191",
+    "id": 7831998
+  }, {
+    "taxon": {"strain": "", "species": "Canis lupus familiaris"},
+    "xrefid": "F1PQ38",
+    "sequence_length": 765,
+    "gc_content": 0.5974760661444735,
+    "protid": "CANLF12646",
+    "id": 7836453
+  }, {
+    "taxon": {"strain": "", "species": "Canis lupus familiaris"},
+    "xrefid": "A7E3K7",
+    "sequence_length": 570,
+    "gc_content": 0.4845300642148278,
+    "protid": "CANLF19678",
+    "id": 7843485
+  }, {
+    "taxon": {"strain": "", "species": "Canis lupus familiaris"},
+    "xrefid": "F1PL03",
+    "sequence_length": 578,
+    "gc_content": 0.47092688543465744,
+    "protid": "CANLF19965",
+    "id": 7843772
+  }, {
+    "taxon": {"strain": "", "species": "Mustela putorius furo"},
+    "xrefid": "M3XSK5",
+    "sequence_length": 573,
+    "gc_content": 0.4988385598141696,
+    "protid": "MUSPF02374",
+    "id": 7846791
+  }, {
+    "taxon": {"strain": "", "species": "Mustela putorius furo"},
+    "xrefid": "M3XT45",
+    "sequence_length": 589,
+    "gc_content": 0.47231638418079097,
+    "protid": "MUSPF02808",
+    "id": 7847225
+  }, {
+    "taxon": {"strain": "", "species": "Mustela putorius furo"},
+    "xrefid": "M3YG53",
+    "sequence_length": 578,
+    "gc_content": 0.4323546344271733,
+    "protid": "MUSPF08726",
+    "id": 7853143
+  }, {
+    "taxon": {"strain": "", "species": "Mustela putorius furo"},
+    "xrefid": "M3XMA7",
+    "sequence_length": 763,
+    "gc_content": 0.5968586387434555,
+    "protid": "MUSPF10850",
+    "id": 7855267
+  }, {
+    "taxon": {"strain": "", "species": "Mustela putorius furo"},
+    "xrefid": "M3YLX9",
+    "sequence_length": 568,
+    "gc_content": 0.4879906268306971,
+    "protid": "MUSPF12368",
+    "id": 7856785
+  }, {
+    "taxon": {"strain": "", "species": "Ailuropoda melanoleuca"},
+    "xrefid": "G1LR96",
+    "sequence_length": 544,
+    "gc_content": 0.4874617737003058,
+    "protid": "AILME03170",
+    "id": 7867492
+  }, {
+    "taxon": {"strain": "", "species": "Ailuropoda melanoleuca"},
+    "xrefid": "G1LF61",
+    "sequence_length": 603,
+    "gc_content": 0.41887417218543044,
+    "protid": "AILME03926",
+    "id": 7868248
+  }, {
+    "taxon": {"strain": "", "species": "Ailuropoda melanoleuca"},
+    "xrefid": "G1M2I2",
+    "sequence_length": 571,
+    "gc_content": 0.5052447552447552,
+    "protid": "AILME04629",
+    "id": 7868951
+  }, {
+    "taxon": {"strain": "", "species": "Ailuropoda melanoleuca"},
+    "xrefid": "G1M6F7",
+    "sequence_length": 765,
+    "gc_content": 0.603568320278503,
+    "protid": "AILME11366",
+    "id": 7875688
+  }, {
+    "taxon": {"strain": "", "species": "Ailuropoda melanoleuca"},
+    "xrefid": "G1LL82",
+    "sequence_length": 570,
+    "gc_content": 0.4868651488616462,
+    "protid": "AILME18599",
+    "id": 7882921
+  }, {
+    "taxon": {"strain": "", "species": "Felis catus"},
+    "xrefid": "M3W5F2",
+    "sequence_length": 573,
+    "gc_content": 0.5087108013937283,
+    "protid": "FELCA06008",
+    "id": 7890146
+  }, {
+    "taxon": {"strain": "", "species": "Felis catus"},
+    "xrefid": "M3VWJ0",
+    "sequence_length": 936,
+    "gc_content": 0.6078291814946619,
+    "protid": "FELCA06334",
+    "id": 7890472
+  }, {
+    "taxon": {"strain": "", "species": "Felis catus"},
+    "xrefid": "M3XET3",
+    "sequence_length": 602,
+    "gc_content": 0.41625207296849087,
+    "protid": "FELCA11480",
+    "id": 7895618
+  }, {
+    "taxon": {"strain": "", "species": "Felis catus"},
+    "xrefid": "M3VZS9",
+    "sequence_length": 570,
+    "gc_content": 0.47869235259778165,
+    "protid": "FELCA18712",
+    "id": 7902850
+  }, {
+    "taxon": {"strain": "", "species": "Felis catus"},
+    "xrefid": "M3W6W6",
+    "sequence_length": 562,
+    "gc_content": 0.46299585553582,
+    "protid": "FELCA18996",
+    "id": 7903134
+  }, {
+    "taxon": {"strain": "", "species": "Tursiops truncatus"},
+    "xrefid": "ENSTTRG00000013557",
+    "sequence_length": 558,
+    "gc_content": 0.4627310673822302,
+    "protid": "TURTR02184",
+    "id": 7905945
+  }, {
+    "taxon": {"strain": "", "species": "Tursiops truncatus"},
+    "xrefid": "ENSTTRG00000012654",
+    "sequence_length": 577,
+    "gc_content": 0.4348327566320646,
+    "protid": "TURTR04606",
+    "id": 7908367
+  }, {
+    "taxon": {"strain": "", "species": "Tursiops truncatus"},
+    "xrefid": "ENSTTRG00000006333",
+    "sequence_length": 568,
+    "gc_content": 0.4932630345635618,
+    "protid": "TURTR09516",
+    "id": 7913277
+  }, {
+    "taxon": {"strain": "", "species": "Tursiops truncatus"},
+    "xrefid": "ENSTTRG00000006752",
+    "sequence_length": 494,
+    "gc_content": 0.4908722109533469,
+    "protid": "TURTR10647",
+    "id": 7914408
+  }, {
+    "taxon": {"strain": "", "species": "Bos taurus"},
+    "xrefid": "A7E3L4",
+    "sequence_length": 755,
+    "gc_content": 0.5789241622574955,
+    "protid": "BOVIN00913",
+    "id": 7921170
+  }, {
+    "taxon": {"strain": "", "species": "Bos taurus"},
+    "xrefid": "F1MQX5",
+    "sequence_length": 578,
+    "gc_content": 0.4369602763385147,
+    "protid": "BOVIN13003",
+    "id": 7933260
+  }, {
+    "taxon": {"strain": "", "species": "Bos taurus"},
+    "xrefid": "E1BFF3",
+    "sequence_length": 566,
+    "gc_content": 0.4879482657260435,
+    "protid": "BOVIN19369",
+    "id": 7939626
+  }, {
+    "taxon": {"strain": "", "species": "Bos taurus"},
+    "xrefid": "E1BPJ7",
+    "sequence_length": 561,
+    "gc_content": 0.4679715302491103,
+    "protid": "BOVIN19749",
+    "id": 7940006
+  }, {
+    "taxon": {"strain": "", "species": "Bos taurus"},
+    "xrefid": "CY24B_BOVIN",
+    "sequence_length": 570,
+    "gc_content": 0.4845300642148278,
+    "protid": "BOVIN20109",
+    "id": 7940366
+  }, {
+    "taxon": {"strain": "", "species": "Ovis aries"},
+    "xrefid": "W5P107",
+    "sequence_length": 594,
+    "gc_content": 0.4403361344537815,
+    "protid": "SHEEP10780",
+    "id": 7951347
+  }, {
+    "taxon": {"strain": "", "species": "Ovis aries"},
+    "xrefid": "W5QB60",
+    "sequence_length": 744,
+    "gc_content": 0.5843400447427293,
+    "protid": "SHEEP17787",
+    "id": 7958354
+  }, {
+    "taxon": {"strain": "", "species": "Ovis aries"},
+    "xrefid": "W5P274",
+    "sequence_length": 568,
+    "gc_content": 0.4879906268306971,
+    "protid": "SHEEP18917",
+    "id": 7959484
+  }, {
+    "taxon": {"strain": "", "species": "Ovis aries"},
+    "xrefid": "W5QC99",
+    "sequence_length": 570,
+    "gc_content": 0.4839462930531232,
+    "protid": "SHEEP19641",
+    "id": 7960208
+  }, {
+    "taxon": {"strain": "", "species": "Ovis aries"},
+    "xrefid": "W5NSH6",
+    "sequence_length": 593,
+    "gc_content": 0.4696969696969697,
+    "protid": "SHEEP20289",
+    "id": 7960856
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000004966.2",
+    "sequence_length": 712,
+    "gc_content": 0.5716292134831461,
+    "protid": "PIGXX00990",
+    "id": 7962641
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000014927.3",
+    "sequence_length": 579,
+    "gc_content": 0.4557471264367816,
+    "protid": "PIGXX18231",
+    "id": 7979882
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000012229.3",
+    "sequence_length": 570,
+    "gc_content": 0.5107997664915354,
+    "protid": "PIGXX19274",
+    "id": 7980925
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000012485.3",
+    "sequence_length": 592,
+    "gc_content": 0.4716132658797077,
+    "protid": "PIGXX19585",
+    "id": 7981236
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000004068.2",
+    "sequence_length": 571,
+    "gc_content": 0.4897959183673469,
+    "protid": "PIGXX20764",
+    "id": 7982415
+  }, {
+    "taxon": {"strain": "", "species": "Sus scrofa"},
+    "xrefid": "ENSSSCG00000028121.1",
+    "sequence_length": 662,
+    "gc_content": 0.5566750629722922,
+    "protid": "PIGXX20825",
+    "id": 7982476
+  }, {
+    "taxon": {"strain": "", "species": "Vicugna pacos"},
+    "xrefid": "ENSVPAG00000010151",
+    "sequence_length": 436,
+    "gc_content": 0.47739463601532567,
+    "protid": "VICPA04017",
+    "id": 7987850
+  }, {
+    "taxon": {"strain": "", "species": "Vicugna pacos"},
+    "xrefid": "ENSVPAG00000006467",
+    "sequence_length": 486,
+    "gc_content": 0.4766803840877915,
+    "protid": "VICPA04520",
+    "id": 7988353
+  }, {
+    "taxon": {"strain": "", "species": "Vicugna pacos"},
+    "xrefid": "ENSVPAG00000011314",
+    "sequence_length": 535,
+    "gc_content": 0.44984423676012464,
+    "protid": "VICPA05338",
+    "id": 7989171
+  }, {
+    "taxon": {"strain": "", "species": "Vicugna pacos"},
+    "xrefid": "ENSVPAG00000002468",
+    "sequence_length": 492,
+    "gc_content": 0.49151391717583165,
+    "protid": "VICPA09755",
+    "id": 7993588
+  }, {
+    "taxon": {"strain": "", "species": "Pteropus vampyrus"},
+    "xrefid": "ENSPVAG00000008343",
+    "sequence_length": 557,
+    "gc_content": 0.468936678614098,
+    "protid": "PTEVA03556",
+    "id": 7999122
+  }, {
+    "taxon": {"strain": "", "species": "Pteropus vampyrus"},
+    "xrefid": "ENSPVAG00000014660",
+    "sequence_length": 762,
+    "gc_content": 0.5736129314110966,
+    "protid": "PTEVA04974",
+    "id": 8000540
+  }, {
+    "taxon": {"strain": "", "species": "Pteropus vampyrus"},
+    "xrefid": "ENSPVAG00000013569",
+    "sequence_length": 486,
+    "gc_content": 0.465979381443299,
+    "protid": "PTEVA08731",
+    "id": 8004297
+  }, {
+    "taxon": {"strain": "", "species": "Pteropus vampyrus"},
+    "xrefid": "ENSPVAG00000015821",
+    "sequence_length": 568,
+    "gc_content": 0.5155243116578794,
+    "protid": "PTEVA14818",
+    "id": 8010384
+  }, {
+    "taxon": {"strain": "", "species": "Myotis lucifugus"},
+    "xrefid": "G1NWI5",
+    "sequence_length": 570,
+    "gc_content": 0.4699357851722125,
+    "protid": "MYOLU01292",
+    "id": 8013805
+  }, {
+    "taxon": {"strain": "", "species": "Myotis lucifugus"},
+    "xrefid": "G1P3C6",
+    "sequence_length": 563,
+    "gc_content": 0.44799054373522457,
+    "protid": "MYOLU02280",
+    "id": 8014793
+  }, {
+    "taxon": {"strain": "", "species": "Myotis lucifugus"},
+    "xrefid": "G1PVN8",
+    "sequence_length": 578,
+    "gc_content": 0.4317789291882556,
+    "protid": "MYOLU07554",
+    "id": 8020067
+  }, {
+    "taxon": {"strain": "", "species": "Myotis lucifugus"},
+    "xrefid": "G1NZ52",
+    "sequence_length": 570,
+    "gc_content": 0.5271453590192644,
+    "protid": "MYOLU08217",
+    "id": 8020730
+  }, {
+    "taxon": {"strain": "", "species": "Myotis lucifugus"},
+    "xrefid": "G1NUR2",
+    "sequence_length": 759,
+    "gc_content": 0.5906099166301009,
+    "protid": "MYOLU15763",
+    "id": 8028276
+  }, {
+    "taxon": {"strain": "", "species": "Erinaceus europaeus"},
+    "xrefid": "ENSEEUG00000011488",
+    "sequence_length": 468,
+    "gc_content": 0.4721030042918455,
+    "protid": "ERIEU09123",
+    "id": 8041498
+  }, {
+    "taxon": {"strain": "", "species": "Erinaceus europaeus"},
+    "xrefid": "ENSEEUG00000009090",
+    "sequence_length": 415,
+    "gc_content": 0.4891041162227603,
+    "protid": "ERIEU11764",
+    "id": 8044139
+  }, {
+    "taxon": {"strain": "", "species": "Sorex araneus"},
+    "xrefid": "ENSSARG00000011105",
+    "sequence_length": 509,
+    "gc_content": 0.44793713163064836,
+    "protid": "SORAR04811",
+    "id": 8051674
+  }, {
+    "taxon": {"strain": "", "species": "Sorex araneus"},
+    "xrefid": "ENSSARG00000011556",
+    "sequence_length": 362,
+    "gc_content": 0.492018779342723,
+    "protid": "SORAR07979",
+    "id": 8054842
+  }, {
+    "taxon": {"strain": "", "species": "Sorex araneus"},
+    "xrefid": "ENSSARG00000005058",
+    "sequence_length": 485,
+    "gc_content": 0.41786941580756015,
+    "protid": "SORAR08404",
+    "id": 8055267
+  }, {
+    "taxon": {"strain": "", "species": "Equus caballus"},
+    "xrefid": "F6ZC07",
+    "sequence_length": 750,
+    "gc_content": 0.6084444444444445,
+    "protid": "HORSE00945",
+    "id": 8060904
+  }, {
+    "taxon": {"strain": "", "species": "Equus caballus"},
+    "xrefid": "F6RG72",
+    "sequence_length": 568,
+    "gc_content": 0.4991212653778559,
+    "protid": "HORSE14180",
+    "id": 8074139
+  }, {
+    "taxon": {"strain": "", "species": "Equus caballus"},
+    "xrefid": "F6RL56",
+    "sequence_length": 577,
+    "gc_content": 0.4429065743944637,
+    "protid": "HORSE17729",
+    "id": 8077688
+  }, {
+    "taxon": {"strain": "", "species": "Equus caballus"},
+    "xrefid": "F7DA90",
+    "sequence_length": 570,
+    "gc_content": 0.4862813776999416,
+    "protid": "HORSE19555",
+    "id": 8079514
+  }, {
+    "taxon": {"strain": "", "species": "Equus caballus"},
+    "xrefid": "F6U8G2",
+    "sequence_length": 564,
+    "gc_content": 0.4731563421828909,
+    "protid": "HORSE19865",
+    "id": 8079824
+  }, {
+    "taxon": {"strain": "", "species": "Dasypus novemcinctus"},
+    "xrefid": "ENSDNOG00000005365",
+    "sequence_length": 767,
+    "gc_content": 0.609375,
+    "protid": "DASNO01043",
+    "id": 8081407
+  }, {
+    "taxon": {"strain": "", "species": "Dasypus novemcinctus"},
+    "xrefid": "ENSDNOG00000011906",
+    "sequence_length": 607,
+    "gc_content": 0.46710526315789475,
+    "protid": "DASNO06049",
+    "id": 8086413
+  }, {
+    "taxon": {"strain": "", "species": "Dasypus novemcinctus"},
+    "xrefid": "ENSDNOG00000013390",
+    "sequence_length": 575,
+    "gc_content": 0.53125,
+    "protid": "DASNO13788",
+    "id": 8094152
+  }, {
+    "taxon": {"strain": "", "species": "Dasypus novemcinctus"},
+    "xrefid": "ENSDNOG00000031609",
+    "sequence_length": 570,
+    "gc_content": 0.4757734967892586,
+    "protid": "DASNO14458",
+    "id": 8094822
+  }, {
+    "taxon": {"strain": "", "species": "Choloepus hoffmanni"},
+    "xrefid": "ENSCHOG00000006384",
+    "sequence_length": 463,
+    "gc_content": 0.46940244780417567,
+    "protid": "CHOHO04557",
+    "id": 8108454
+  }, {
+    "taxon": {"strain": "", "species": "Choloepus hoffmanni"},
+    "xrefid": "ENSCHOG00000011680",
+    "sequence_length": 358,
+    "gc_content": 0.45318352059925093,
+    "protid": "CHOHO05175",
+    "id": 8109072
+  }, {
+    "taxon": {"strain": "", "species": "Choloepus hoffmanni"},
+    "xrefid": "ENSCHOG00000000370",
+    "sequence_length": 553,
+    "gc_content": 0.48523206751054854,
+    "protid": "CHOHO10291",
+    "id": 8114188
+  }, {
+    "taxon": {"strain": "", "species": "Sarcophilus harrisii"},
+    "xrefid": "G3VR45",
+    "sequence_length": 578,
+    "gc_content": 0.43062751871042027,
+    "protid": "SARHA00086",
+    "id": 8116312
+  }, {
+    "taxon": {"strain": "", "species": "Sarcophilus harrisii"},
+    "xrefid": "G3WMH8",
+    "sequence_length": 462,
+    "gc_content": 0.4213564213564214,
+    "protid": "SARHA04536",
+    "id": 8120762
+  }, {
+    "taxon": {"strain": "", "species": "Sarcophilus harrisii"},
+    "xrefid": "G3W2Y0",
+    "sequence_length": 447,
+    "gc_content": 0.43027591349739003,
+    "protid": "SARHA07745",
+    "id": 8123971
+  }, {
+    "taxon": {"strain": "", "species": "Sarcophilus harrisii"},
+    "xrefid": "G3WGI5",
+    "sequence_length": 742,
+    "gc_content": 0.4737550471063257,
+    "protid": "SARHA11200",
+    "id": 8127426
+  }, {
+    "taxon": {"strain": "", "species": "Monodelphis domestica"},
+    "xrefid": "F7ELK5",
+    "sequence_length": 567,
+    "gc_content": 0.4126984126984127,
+    "protid": "MONDO02850",
+    "id": 8138413
+  }, {
+    "taxon": {"strain": "", "species": "Monodelphis domestica"},
+    "xrefid": "F6U2X4",
+    "sequence_length": 573,
+    "gc_content": 0.4349593495934959,
+    "protid": "MONDO06547",
+    "id": 8142110
+  }, {
+    "taxon": {"strain": "", "species": "Monodelphis domestica"},
+    "xrefid": "F6Z703",
+    "sequence_length": 578,
+    "gc_content": 0.4294761082325849,
+    "protid": "MONDO07829",
+    "id": 8143392
+  }, {
+    "taxon": {"strain": "", "species": "Macropus eugenii"},
+    "xrefid": "ENSMEUG00000013478",
+    "sequence_length": 487,
+    "gc_content": 0.5099519560741249,
+    "protid": "MACEU03997",
+    "id": 8156404
+  }, {
+    "taxon": {"strain": "", "species": "Macropus eugenii"},
+    "xrefid": "ENSMEUG00000001962",
+    "sequence_length": 599,
+    "gc_content": 0.5066889632107023,
+    "protid": "MACEU06147",
+    "id": 8158554
+  }, {
+    "taxon": {"strain": "", "species": "Macropus eugenii"},
+    "xrefid": "ENSMEUG00000009422",
+    "sequence_length": 569,
+    "gc_content": 0.443859649122807,
+    "protid": "MACEU08255",
+    "id": 8160662
+  }, {
+    "taxon": {"strain": "", "species": "Macropus eugenii"},
+    "xrefid": "ENSMEUG00000010109",
+    "sequence_length": 466,
+    "gc_content": 0.4295977011494253,
+    "protid": "MACEU12246",
+    "id": 8164653
+  }, {
+    "taxon": {"strain": "", "species": "Macropus eugenii"},
+    "xrefid": "ENSMEUG00000007194",
+    "sequence_length": 388,
+    "gc_content": 0.42421602787456447,
+    "protid": "MACEU14485",
+    "id": 8166892
+  }, {
+    "taxon": {"strain": "", "species": "Anas platyrhynchos"},
+    "xrefid": "U3IGI5",
+    "sequence_length": 568,
+    "gc_content": 0.43233743409490333,
+    "protid": "ANAPL06330",
+    "id": 8173999
+  }, {
+    "taxon": {"strain": "", "species": "Anas platyrhynchos"},
+    "xrefid": "U3IN50",
+    "sequence_length": 572,
+    "gc_content": 0.4607329842931937,
+    "protid": "ANAPL08071",
+    "id": 8175740
+  }, {
+    "taxon": {"strain": "", "species": "Anas platyrhynchos"},
+    "xrefid": "U3IFZ3",
+    "sequence_length": 564,
+    "gc_content": 0.6017699115044248,
+    "protid": "ANAPL08172",
+    "id": 8175841
+  }, {
+    "taxon": {"strain": "", "species": "Anas platyrhynchos"},
+    "xrefid": "U3IYN1",
+    "sequence_length": 583,
+    "gc_content": 0.4526255707762557,
+    "protid": "ANAPL11061",
+    "id": 8178730
+  }, {
+    "taxon": {"strain": "", "species": "Anas platyrhynchos"},
+    "xrefid": "U3ID26",
+    "sequence_length": 744,
+    "gc_content": 0.6565158978952083,
+    "protid": "ANAPL11636",
+    "id": 8179305
+  }, {
+    "taxon": {"strain": "", "species": "Meleagris gallopavo"},
+    "xrefid": "G1NP55",
+    "sequence_length": 571,
+    "gc_content": 0.4574592074592075,
+    "protid": "MELGA01360",
+    "id": 8184782
+  }, {
+    "taxon": {"strain": "", "species": "Meleagris gallopavo"},
+    "xrefid": "G1NQP5",
+    "sequence_length": 563,
+    "gc_content": 0.4438534278959811,
+    "protid": "MELGA01941",
+    "id": 8185363
+  }, {
+    "taxon": {"strain": "", "species": "Meleagris gallopavo"},
+    "xrefid": "G1NCS3",
+    "sequence_length": 739,
+    "gc_content": 0.6261261261261262,
+    "protid": "MELGA03267",
+    "id": 8186689
+  }, {
+    "taxon": {"strain": "", "species": "Meleagris gallopavo"},
+    "xrefid": "G1NJH6",
+    "sequence_length": 568,
+    "gc_content": 0.4370240187463386,
+    "protid": "MELGA05945",
+    "id": 8189367
+  }, {
+    "taxon": {"strain": "", "species": "Meleagris gallopavo"},
+    "xrefid": "G1MY90",
+    "sequence_length": 585,
+    "gc_content": 0.5620022753128555,
+    "protid": "MELGA12960",
+    "id": 8196382
+  }, {
+    "taxon": {"strain": "", "species": "Gallus gallus"},
+    "xrefid": "A7E3K8",
+    "sequence_length": 571,
+    "gc_content": 0.4627039627039627,
+    "protid": "CHICK01309",
+    "id": 8199358
+  }, {
+    "taxon": {"strain": "", "species": "Gallus gallus"},
+    "xrefid": "F1NWG5",
+    "sequence_length": 582,
+    "gc_content": 0.4528301886792453,
+    "protid": "CHICK01873",
+    "id": 8199922
+  }, {
+    "taxon": {"strain": "", "species": "Gallus gallus"},
+    "xrefid": "ENSGALG00000008063",
+    "sequence_length": 750,
+    "gc_content": 0.6626719928983578,
+    "protid": "CHICK02372",
+    "id": 8200421
+  }, {
+    "taxon": {"strain": "", "species": "Gallus gallus"},
+    "xrefid": "F1NVG4",
+    "sequence_length": 568,
+    "gc_content": 0.44229642647920325,
+    "protid": "CHICK09174",
+    "id": 8207223
+  }, {
+    "taxon": {"strain": "", "species": "Gallus gallus"},
+    "xrefid": "ENSGALG00000006707",
+    "sequence_length": 565,
+    "gc_content": 0.5795053003533569,
+    "protid": "CHICK09920",
+    "id": 8207969
+  }, {
+    "taxon": {"strain": "", "species": "Ficedula albicollis"},
+    "xrefid": "U3KDG6",
+    "sequence_length": 567,
+    "gc_content": 0.4465962441314554,
+    "protid": "FICAL00152",
+    "id": 8213705
+  }, {
+    "taxon": {"strain": "", "species": "Ficedula albicollis"},
+    "xrefid": "U3JML0",
+    "sequence_length": 563,
+    "gc_content": 0.5981087470449172,
+    "protid": "FICAL06596",
+    "id": 8220149
+  }, {
+    "taxon": {"strain": "", "species": "Ficedula albicollis"},
+    "xrefid": "U3JZL9",
+    "sequence_length": 600,
+    "gc_content": 0.47809206877426513,
+    "protid": "FICAL06750",
+    "id": 8220303
+  }, {
+    "taxon": {"strain": "", "species": "Ficedula albicollis"},
+    "xrefid": "U3JFV7",
+    "sequence_length": 570,
+    "gc_content": 0.4845300642148278,
+    "protid": "FICAL09632",
+    "id": 8223185
+  }, {
+    "taxon": {"strain": "", "species": "Taeniopygia guttata"},
+    "xrefid": "H0Z8X7",
+    "sequence_length": 570,
+    "gc_content": 0.47869235259778165,
+    "protid": "TAEGU00092",
+    "id": 8229028
+  }, {
+    "taxon": {"strain": "", "species": "Taeniopygia guttata"},
+    "xrefid": "H0ZRN8",
+    "sequence_length": 565,
+    "gc_content": 0.45132743362831856,
+    "protid": "TAEGU00661",
+    "id": 8229597
+  }, {
+    "taxon": {"strain": "", "species": "Taeniopygia guttata"},
+    "xrefid": "H0ZLK1",
+    "sequence_length": 567,
+    "gc_content": 0.44072769953051644,
+    "protid": "TAEGU08535",
+    "id": 8237471
+  }, {
+    "taxon": {"strain": "", "species": "Pelodiscus sinensis"},
+    "xrefid": "K7F6L7",
+    "sequence_length": 563,
+    "gc_content": 0.5673758865248227,
+    "protid": "PELSI09556",
+    "id": 8255596
+  }, {
+    "taxon": {"strain": "", "species": "Pelodiscus sinensis"},
+    "xrefid": "K7FK13",
+    "sequence_length": 572,
+    "gc_content": 0.4409540430482839,
+    "protid": "PELSI09598",
+    "id": 8255638
+  }, {
+    "taxon": {"strain": "", "species": "Pelodiscus sinensis"},
+    "xrefid": "K7GHR7",
+    "sequence_length": 459,
+    "gc_content": 0.45,
+    "protid": "PELSI10810",
+    "id": 8256850
+  }, {
+    "taxon": {"strain": "", "species": "Pelodiscus sinensis"},
+    "xrefid": "K7G8Z5",
+    "sequence_length": 755,
+    "gc_content": 0.5573192239858906,
+    "protid": "PELSI13175",
+    "id": 8259215
+  }, {
+    "taxon": {"strain": "", "species": "Pelodiscus sinensis"},
+    "xrefid": "ENSPSIG00000009070",
+    "sequence_length": 523,
+    "gc_content": 0.41236456341618866,
+    "protid": "PELSI17724",
+    "id": 8263764
+  }, {
+    "taxon": {"strain": "", "species": "Anolis carolinensis"},
+    "xrefid": "G1KDS8",
+    "sequence_length": 568,
+    "gc_content": 0.4299941417691857,
+    "protid": "ANOCA01584",
+    "id": 8265942
+  }, {
+    "taxon": {"strain": "", "species": "Anolis carolinensis"},
+    "xrefid": "ENSACAG00000014880",
+    "sequence_length": 439,
+    "gc_content": 0.43432042520880787,
+    "protid": "ANOCA04767",
+    "id": 8269125
+  }, {
+    "taxon": {"strain": "", "species": "Anolis carolinensis"},
+    "xrefid": "ENSACAG00000014875",
+    "sequence_length": 527,
+    "gc_content": 0.4671717171717172,
+    "protid": "ANOCA05241",
+    "id": 8269599
+  }, {
+    "taxon": {"strain": "", "species": "Anolis carolinensis"},
+    "xrefid": "H9G5K3",
+    "sequence_length": 737,
+    "gc_content": 0.48283649503161696,
+    "protid": "ANOCA15111",
+    "id": 8279469
+  }, {
+    "taxon": {"strain": "", "species": "Xenopus tropicalis"},
+    "xrefid": "F6Y711",
+    "sequence_length": 753,
+    "gc_content": 0.45800176834659595,
+    "protid": "XENTR02667",
+    "id": 8285054
+  }, {
+    "taxon": {"strain": "", "species": "Xenopus tropicalis"},
+    "xrefid": "F7CLH6",
+    "sequence_length": 584,
+    "gc_content": 0.4811858608893957,
+    "protid": "XENTR08484",
+    "id": 8290871
+  }, {
+    "taxon": {"strain": "", "species": "Xenopus tropicalis"},
+    "xrefid": "F6Y341",
+    "sequence_length": 575,
+    "gc_content": 0.43171296296296297,
+    "protid": "XENTR10269",
+    "id": 8292656
+  }, {
+    "taxon": {"strain": "", "species": "Xenopus tropicalis"},
+    "xrefid": "F7AMC8",
+    "sequence_length": 571,
+    "gc_content": 0.45163170163170163,
+    "protid": "XENTR12604",
+    "id": 8294991
+  }, {
+    "taxon": {"strain": "", "species": "Ciona intestinalis"},
+    "xrefid": "F6YS00",
+    "sequence_length": 811,
+    "gc_content": 0.41133004926108374,
+    "protid": "CIOIN08539",
+    "id": 8310217
+  }, {
+    "taxon": {"strain": "", "species": "Ciona intestinalis"},
+    "xrefid": "F6VAT4",
+    "sequence_length": 580,
+    "gc_content": 0.4102122776821572,
+    "protid": "CIOIN08659",
+    "id": 8310337
+  }, {
+    "taxon": {"strain": "", "species": "Ciona savignyi"},
+    "xrefid": "H2Y784",
+    "sequence_length": 782,
+    "gc_content": 0.4955300127713921,
+    "protid": "CIOSA02423",
+    "id": 8320601
+  }, {
+    "taxon": {"strain": "", "species": "Ciona savignyi"},
+    "xrefid": "H2Y443",
+    "sequence_length": 499,
+    "gc_content": 0.4886666666666667,
+    "protid": "CIOSA05494",
+    "id": 8323672
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "W4ZES7",
+    "sequence_length": 1115,
+    "gc_content": 0.4622082897944967,
+    "protid": "STRPU03699",
+    "id": 8335813
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "W4XL61",
+    "sequence_length": 424,
+    "gc_content": 0.45108695652173914,
+    "protid": "STRPU10305",
+    "id": 8342419
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "",
+    "sequence_length": 537,
+    "gc_content": 0.4708798017348203,
+    "protid": "STRPU13877",
+    "id": 8345991
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "W4ZJ08",
+    "sequence_length": 900,
+    "gc_content": 0.5033282130056324,
+    "protid": "STRPU17050",
+    "id": 8349164
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "W4YZE5",
+    "sequence_length": 574,
+    "gc_content": 0.44611528822055135,
+    "protid": "STRPU18742",
+    "id": 8350856
+  }, {
+    "taxon": {"strain": "", "species": "Strongylocentrotus purpuratus"},
+    "xrefid": "W4XAW6",
+    "sequence_length": 767,
+    "gc_content": 0.4748263888888889,
+    "protid": "STRPU26067",
+    "id": 8358181
+  }, {
+    "taxon": {"strain": "", "species": "Pristionchus pacificus"},
+    "xrefid": "H3FQT2",
+    "sequence_length": 793,
+    "gc_content": 0.5730478589420654,
+    "protid": "PRIPA24393",
+    "id": 8394793
+  }, {
+    "taxon": {"strain": "", "species": "Caenorhabditis japonica"},
+    "xrefid": "",
+    "sequence_length": 900,
+    "gc_content": 0.5005549389567148,
+    "protid": "CAEJA07494",
+    "id": 8487534
+  }, {
+    "taxon": {"strain": "", "species": "Brugia malayi"},
+    "xrefid": "A0A1I9GCE7",
+    "sequence_length": 945,
+    "gc_content": 0.3960535588442565,
+    "protid": "BRUMA02536",
+    "id": 8532643
+  }, {
+    "taxon": {"strain": "", "species": "Sarcoptes scabiei"},
+    "xrefid": "A0A132AKU2",
+    "sequence_length": 397,
+    "gc_content": 0.38860971524288107,
+    "protid": "SARSC05096",
+    "id": 8592987
+  }, {
+    "taxon": {"strain": "", "species": "Tetranychus urticae"},
+    "xrefid": "T1KJ94",
+    "sequence_length": 649,
+    "gc_content": 0.3707692307692308,
+    "protid": "TETUR08135",
+    "id": 8606415
+  }, {
+    "taxon": {"strain": "", "species": "Tetranychus urticae"},
+    "xrefid": "T1JRL2",
+    "sequence_length": 649,
+    "gc_content": 0.37743589743589745,
+    "protid": "TETUR17128",
+    "id": 8615408
+  }, {
+    "taxon": {"strain": "", "species": "Tetranychus urticae"},
+    "xrefid": "T1JRX3",
+    "sequence_length": 723,
+    "gc_content": 0.3770718232044199,
+    "protid": "TETUR17242",
+    "id": 8615522
+  }, {
+    "taxon": {"strain": "", "species": "Ixodes scapularis"},
+    "xrefid": "B7PDQ2",
+    "sequence_length": 727,
+    "gc_content": 0.5993589743589743,
+    "protid": "IXOSC19148",
+    "id": 8635447
+  }, {
+    "taxon": {"strain": "", "species": "Strigamia maritima"},
+    "xrefid": "T1IPL8",
+    "sequence_length": 564,
+    "gc_content": 0.3480825958702065,
+    "protid": "STRMM09379",
+    "id": 8646132
+  }, {
+    "taxon": {"strain": "", "species": "Daphnia pulex"},
+    "xrefid": "E9GYG9",
+    "sequence_length": 1095,
+    "gc_content": 0.48023114355231145,
+    "protid": "DAPPU07272",
+    "id": 8658913
+  }, {
+    "taxon": {"strain": "", "species": "Daphnia pulex"},
+    "xrefid": "E9GYH0",
+    "sequence_length": 992,
+    "gc_content": 0.44142329640819067,
+    "protid": "DAPPU07273",
+    "id": 8658914
+  }, {
+    "taxon": {"strain": "", "species": "Daphnia pulex"},
+    "xrefid": "E9GYH1",
+    "sequence_length": 1106,
+    "gc_content": 0.43390545016561277,
+    "protid": "DAPPU07274",
+    "id": 8658915
+  }, {
+    "taxon": {"strain": "", "species": "Daphnia pulex"},
+    "xrefid": "E9GWP9",
+    "sequence_length": 449,
+    "gc_content": 0.502962962962963,
+    "protid": "DAPPU23176",
+    "id": 8674817
+  }, {
+    "taxon": {"strain": "", "species": "Daphnia pulex"},
+    "xrefid": "E9HKT2",
+    "sequence_length": 772,
+    "gc_content": 0.5442000862440707,
+    "protid": "DAPPU23820",
+    "id": 8675461
+  }, {
+    "taxon": {"strain": "", "species": "Lepeophtheirus salmonis"},
+    "xrefid": "",
+    "sequence_length": 982,
+    "gc_content": 0.40944614339109753,
+    "protid": "LEPSM01887",
+    "id": 8683616
+  }, {
+    "taxon": {"strain": "", "species": "Lepeophtheirus salmonis"},
+    "xrefid": "",
+    "sequence_length": 763,
+    "gc_content": 0.4163390126692879,
+    "protid": "LEPSM03801",
+    "id": 8685530
+  }, {
+    "taxon": {"strain": "", "species": "Lepeophtheirus salmonis"},
+    "xrefid": "",
+    "sequence_length": 1024,
+    "gc_content": 0.3850911458333333,
+    "protid": "LEPSM12905",
+    "id": 8694634
+  }, {
+    "taxon": {"strain": "", "species": "Bombyx mori"},
+    "xrefid": "H9JWA3",
+    "sequence_length": 1086,
+    "gc_content": 0.504753143207605,
+    "protid": "BOMMO13781",
+    "id": 8708522
+  }, {
+    "taxon": {"strain": "", "species": "Danaus plexippus"},
+    "xrefid": "A0A212EKS1",
+    "sequence_length": 573,
+    "gc_content": 0.42334494773519166,
+    "protid": "DANPL11095",
+    "id": 8720413
+  }, {
+    "taxon": {"strain": "", "species": "Melitaea cinxia"},
+    "xrefid": "",
+    "sequence_length": 468,
+    "gc_content": 0.4058280028429282,
+    "protid": "MELCN12949",
+    "id": 8751321
+  }, {
+    "taxon": {"strain": "", "species": "Dendroctonus ponderosae"},
+    "xrefid": "N6SSZ1",
+    "sequence_length": 1105,
+    "gc_content": 0.42503770739064856,
+    "protid": "DENPD07961",
+    "id": 8762961
+  }, {
+    "taxon": {"strain": "", "species": "Tribolium castaneum"},
+    "xrefid": "",
+    "sequence_length": 405,
+    "gc_content": 0.45977011494252873,
+    "protid": "TRICA00658",
+    "id": 8768263
+  }, {
+    "taxon": {"strain": "", "species": "Tribolium castaneum"},
+    "xrefid": "",
+    "sequence_length": 1108,
+    "gc_content": 0.43733092876465285,
+    "protid": "TRICA08179",
+    "id": 8775784
+  }, {
+    "taxon": {"strain": "", "species": "Megaselia scalaris"},
+    "xrefid": "T1GFW8",
+    "sequence_length": 507,
+    "gc_content": 0.38123359580052496,
+    "protid": "MEGSC11145",
+    "id": 8793548
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila virilis"},
+    "xrefid": "FBgn0206051",
+    "sequence_length": 1105,
+    "gc_content": 0.5687160940325497,
+    "protid": "DROVI03950",
+    "id": 8797781
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila grimshawi"},
+    "xrefid": "B4J941",
+    "sequence_length": 1108,
+    "gc_content": 0.5350165314096784,
+    "protid": "DROGR10959",
+    "id": 8819141
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila biarmipes"},
+    "xrefid": "",
+    "sequence_length": 1341,
+    "gc_content": 0.5689783743475019,
+    "protid": "DROBM09807",
+    "id": 8832593
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila elegans"},
+    "xrefid": "",
+    "sequence_length": 1305,
+    "gc_content": 0.5836526181353767,
+    "protid": "DROEL12287",
+    "id": 8850883
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila erecta"},
+    "xrefid": "B3NPK3",
+    "sequence_length": 1087,
+    "gc_content": 0.5419730392156863,
+    "protid": "DROER07739",
+    "id": 8861216
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila eugracilis"},
+    "xrefid": "",
+    "sequence_length": 1341,
+    "gc_content": 0.5105642555306985,
+    "protid": "DROEU00376",
+    "id": 8868678
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila ficusphila"},
+    "xrefid": "A0A1W4UXX6",
+    "sequence_length": 1336,
+    "gc_content": 0.5541417165668663,
+    "protid": "DROFC04323",
+    "id": 8887140
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila melanogaster"},
+    "xrefid": "A0A0B4LFI7",
+    "sequence_length": 1282,
+    "gc_content": 0.5341647181085997,
+    "protid": "DROME06470",
+    "id": 8917325
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila persimilis"},
+    "xrefid": "B4GAC4",
+    "sequence_length": 1092,
+    "gc_content": 0.5794449527294907,
+    "protid": "DROPE13314",
+    "id": 8946280
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila pseudoobscura pseudoobscura"},
+    "xrefid": "FBgn0077768",
+    "sequence_length": 1092,
+    "gc_content": 0.5782250686184812,
+    "protid": "DROPS10133",
+    "id": 8959766
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila rhopaloa"},
+    "xrefid": "",
+    "sequence_length": 1334,
+    "gc_content": 0.5527236381809095,
+    "protid": "DRORH05849",
+    "id": 8971400
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila sechellia"},
+    "xrefid": "B4HSW3",
+    "sequence_length": 1087,
+    "gc_content": 0.538296568627451,
+    "protid": "DROSE12387",
+    "id": 8992443
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila simulans"},
+    "xrefid": "B4QHX1",
+    "sequence_length": 1087,
+    "gc_content": 0.5386029411764706,
+    "protid": "DROSI04168",
+    "id": 9000203
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila takahashii"},
+    "xrefid": "",
+    "sequence_length": 1308,
+    "gc_content": 0.5591233435270132,
+    "protid": "DROTK02845",
+    "id": 9014181
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila willistoni"},
+    "xrefid": "FBgn0222898",
+    "sequence_length": 1099,
+    "gc_content": 0.4584848484848485,
+    "protid": "DROWI13430",
+    "id": 9038225
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila yakuba"},
+    "xrefid": "B4P689",
+    "sequence_length": 1087,
+    "gc_content": 0.5471813725490197,
+    "protid": "DROYA04853",
+    "id": 9044893
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila ananassae"},
+    "xrefid": "FBgn0090619",
+    "sequence_length": 1088,
+    "gc_content": 0.5454545454545454,
+    "protid": "DROAN08724",
+    "id": 9064609
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila bipectinata"},
+    "xrefid": "",
+    "sequence_length": 1341,
+    "gc_content": 0.5550584141188168,
+    "protid": "DROBP09256",
+    "id": 9080050
+  }, {
+    "taxon": {"strain": "", "species": "Drosophila mojavensis"},
+    "xrefid": "FBgn0142597",
+    "sequence_length": 1092,
+    "gc_content": 0.5757853003964624,
+    "protid": "DROMO05881",
+    "id": 9090940
+  }, {
+    "taxon": {"strain": "", "species": "Lucilia cuprina"},
+    "xrefid": "A0A0L0C006",
+    "sequence_length": 1520,
+    "gc_content": 0.3708086785009862,
+    "protid": "LUCCU05643",
+    "id": 9105176
+  }, {
+    "taxon": {"strain": "", "species": "Anopheles gambiae"},
+    "xrefid": "",
+    "sequence_length": 490,
+    "gc_content": 0.48336727766463,
+    "protid": "ANOGA05592",
+    "id": 9119226
+  }, {
+    "taxon": {"strain": "", "species": "Anopheles gambiae"},
+    "xrefid": "Q7PNG0",
+    "sequence_length": 1053,
+    "gc_content": 0.5702087286527514,
+    "protid": "ANOGA08794",
+    "id": 9122428
+  }, {
+    "taxon": {"strain": "", "species": "Anopheles darlingi"},
+    "xrefid": "W5JPE1",
+    "sequence_length": 722,
+    "gc_content": 0.5560165975103735,
+    "protid": "ANODA03616",
+    "id": 9129749
+  }, {
+    "taxon": {"strain": "", "species": "Anopheles darlingi"},
+    "xrefid": "W5J710",
+    "sequence_length": 334,
+    "gc_content": 0.47562189054726367,
+    "protid": "ANODA07591",
+    "id": 9133724
+  }, {
+    "taxon": {"strain": "", "species": "Aedes aegypti"},
+    "xrefid": "Q16TN6",
+    "sequence_length": 490,
+    "gc_content": 0.4663951120162933,
+    "protid": "AEDAE04746",
+    "id": 9141320
+  }, {
+    "taxon": {"strain": "", "species": "Aedes aegypti"},
+    "xrefid": "Q17JM4",
+    "sequence_length": 877,
+    "gc_content": 0.5296127562642369,
+    "protid": "AEDAE10172",
+    "id": 9146746
+  }, {
+    "taxon": {"strain": "", "species": "Culex quinquefasciatus"},
+    "xrefid": "B0WUN3",
+    "sequence_length": 561,
+    "gc_content": 0.5106761565836299,
+    "protid": "CULQU13050",
+    "id": 9164753
+  }, {
+    "taxon": {"strain": "", "species": "Apis mellifera"},
+    "xrefid": "",
+    "sequence_length": 1096,
+    "gc_content": 0.3907626861136433,
+    "protid": "APIME09019",
+    "id": 9179364
+  }, {
+    "taxon": {"strain": "", "species": "Bombus impatiens"},
+    "xrefid": "",
+    "sequence_length": 1106,
+    "gc_content": 0.41945197229750075,
+    "protid": "BOMIM02879",
+    "id": 9183602
+  }, {
+    "taxon": {"strain": "", "species": "Linepithema humile"},
+    "xrefid": "",
+    "sequence_length": 1118,
+    "gc_content": 0.3955913017575216,
+    "protid": "LINHU01350",
+    "id": 9197915
+  }, {
+    "taxon": {"strain": "", "species": "Cerapachys biroi"},
+    "xrefid": "",
+    "sequence_length": 1121,
+    "gc_content": 0.4673202614379085,
+    "protid": "CERBI05285",
+    "id": 9219480
+  }, {
+    "taxon": {"strain": "", "species": "Camponotus floridanus"},
+    "xrefid": "E2AH28",
+    "sequence_length": 1127,
+    "gc_content": 0.4078014184397163,
+    "protid": "CAMFO07538",
+    "id": 9238036
+  }, {
+    "taxon": {"strain": "", "species": "Atta cephalotes"},
+    "xrefid": "",
+    "sequence_length": 1047,
+    "gc_content": 0.3842239185750636,
+    "protid": "ATTCE16616",
+    "id": 9261860
+  }, {
+    "taxon": {"strain": "", "species": "Solenopsis invicta"},
+    "xrefid": "",
+    "sequence_length": 1107,
+    "gc_content": 0.3980728696175851,
+    "protid": "SOLIN12962",
+    "id": 9275972
+  }, {
+    "taxon": {"strain": "", "species": "Solenopsis invicta"},
+    "xrefid": "",
+    "sequence_length": 937,
+    "gc_content": 0.37606837606837606,
+    "protid": "SOLIN12965",
+    "id": 9275975
+  }, {
+    "taxon": {"strain": "", "species": "Harpegnathos saltator"},
+    "xrefid": "E2B3W7",
+    "sequence_length": 1117,
+    "gc_content": 0.5008944543828264,
+    "protid": "HARSA04104",
+    "id": 9283492
+  }, {
+    "taxon": {"strain": "", "species": "Harpegnathos saltator"},
+    "xrefid": "E2C8U7",
+    "sequence_length": 751,
+    "gc_content": 0.3953900709219858,
+    "protid": "HARSA14184",
+    "id": 9293572
+  }, {
+    "taxon": {"strain": "", "species": "Rhodnius prolixus"},
+    "xrefid": "T1HWA9",
+    "sequence_length": 1120,
+    "gc_content": 0.42134998513232236,
+    "protid": "RHOPR07990",
+    "id": 9319349
+  }, {
+    "taxon": {"strain": "subsp. corporis", "species": "Pediculus humanus "},
+    "xrefid": "E0VQY4",
+    "sequence_length": 973,
+    "gc_content": 0.35523613963039014,
+    "protid": "PEDHC09994",
+    "id": 9370390
+  }, {
+    "taxon": {"strain": "", "species": "Zootermopsis nevadensis"},
+    "xrefid": "A0A067QT92",
+    "sequence_length": 1005,
+    "gc_content": 0.4701789264413519,
+    "protid": "ZOONE13351",
+    "id": 9384480
+  }, {
+    "taxon": {"strain": "", "species": "Hypsibius dujardini"},
+    "xrefid": "",
+    "sequence_length": 717,
+    "gc_content": 0.5547818012999072,
+    "protid": "HYPDU01221",
+    "id": 9386686
+  }, {
+    "taxon": {"strain": "", "species": "Hypsibius dujardini"},
+    "xrefid": "",
+    "sequence_length": 938,
+    "gc_content": 0.4763933262335818,
+    "protid": "HYPDU06773",
+    "id": 9392238
+  }, {
+    "taxon": {"strain": "", "species": "Hypsibius dujardini"},
+    "xrefid": "",
+    "sequence_length": 656,
+    "gc_content": 0.5060975609756098,
+    "protid": "HYPDU08774",
+    "id": 9394239
+  }, {
+    "taxon": {"strain": "", "species": "Hypsibius dujardini"},
+    "xrefid": "",
+    "sequence_length": 809,
+    "gc_content": 0.5374485596707819,
+    "protid": "HYPDU12409",
+    "id": 9397874
+  }, {
+    "taxon": {"strain": "", "species": "Helobdella robusta"},
+    "xrefid": "T1FYK3",
+    "sequence_length": 554,
+    "gc_content": 0.406006006006006,
+    "protid": "HELRO02482",
+    "id": 9410599
+  }, {
+    "taxon": {"strain": "", "species": "Capitella sp. 1"},
+    "xrefid": "",
+    "sequence_length": 745,
+    "gc_content": 0.47989276139410186,
+    "protid": "CAPI100426",
+    "id": 9431806
+  }, {
+    "taxon": {"strain": "", "species": "Capitella sp. 1"},
+    "xrefid": "",
+    "sequence_length": 726,
+    "gc_content": 0.48464007336084364,
+    "protid": "CAPI100427",
+    "id": 9431807
+  }, {
+    "taxon": {"strain": "", "species": "Capitella sp. 1"},
+    "xrefid": "",
+    "sequence_length": 579,
+    "gc_content": 0.44022988505747124,
+    "protid": "CAPI112826",
+    "id": 9444206
+  }, {
+    "taxon": {"strain": "", "species": "Capitella teleta"},
+    "xrefid": "X2ATU6",
+    "sequence_length": 579,
+    "gc_content": 0.44022988505747124,
+    "protid": "CAPTE14002",
+    "id": 9476944
+  }, {
+    "taxon": {"strain": "", "species": "Capitella teleta"},
+    "xrefid": "R7UNX8",
+    "sequence_length": 745,
+    "gc_content": 0.47989276139410186,
+    "protid": "CAPTE17669",
+    "id": 9480611
+  }, {
+    "taxon": {"strain": "", "species": "Capitella teleta"},
+    "xrefid": "R7UMD4",
+    "sequence_length": 726,
+    "gc_content": 0.48464007336084364,
+    "protid": "CAPTE17670",
+    "id": 9480612
+  }, {
+    "taxon": {"strain": "", "species": "Lingula unguis"},
+    "xrefid": "",
+    "sequence_length": 1082,
+    "gc_content": 0.492151431209603,
+    "protid": "LINUN19317",
+    "id": 9513584
+  }, {
+    "taxon": {"strain": "", "species": "Lingula unguis"},
+    "xrefid": "",
+    "sequence_length": 556,
+    "gc_content": 0.4446439257929384,
+    "protid": "LINUN20667",
+    "id": 9514934
+  }, {
+    "taxon": {"strain": "", "species": "Lingula unguis"},
+    "xrefid": "A0A1S3ISI5",
+    "sequence_length": 910,
+    "gc_content": 0.49140139041346503,
+    "protid": "LINUN26150",
+    "id": 9520417
+  }, {
+    "taxon": {"strain": "", "species": "Lingula unguis"},
+    "xrefid": "",
+    "sequence_length": 571,
+    "gc_content": 0.4324009324009324,
+    "protid": "LINUN27987",
+    "id": 9522254
+  }, {
+    "taxon": {"strain": "", "species": "Lingula unguis"},
+    "xrefid": "",
+    "sequence_length": 554,
+    "gc_content": 0.43663663663663665,
+    "protid": "LINUN28122",
+    "id": 9522389
+  }, {
+    "taxon": {"strain": "", "species": "Crassostrea gigas"},
+    "xrefid": "K1R0W6",
+    "sequence_length": 721,
+    "gc_content": 0.48291782086795937,
+    "protid": "CRAGI04174",
+    "id": 9531614
+  }, {
+    "taxon": {"strain": "", "species": "Crassostrea gigas"},
+    "xrefid": "K1RA82",
+    "sequence_length": 435,
+    "gc_content": 0.45871559633027525,
+    "protid": "CRAGI22830",
+    "id": 9550270
+  }, {
+    "taxon": {"strain": "", "species": "Octopus bimaculoides"},
+    "xrefid": "A0A0L8H1K3",
+    "sequence_length": 573,
+    "gc_content": 0.3710801393728223,
+    "protid": "OCTBM20412",
+    "id": 9573701
+  }, {
+    "taxon": {"strain": "", "species": "Lottia gigantea"},
+    "xrefid": "V4ADF2",
+    "sequence_length": 563,
+    "gc_content": 0.3557919621749409,
+    "protid": "LOTGI08207",
+    "id": 9595083
+  }, {
+    "taxon": {"strain": "", "species": "Lottia gigantea"},
+    "xrefid": "V3ZIL4",
+    "sequence_length": 501,
+    "gc_content": 0.33665338645418325,
+    "protid": "LOTGI09359",
+    "id": 9596235
+  }, {
+    "taxon": {"strain": "", "species": "Lottia gigantea"},
+    "xrefid": "V4AMP5",
+    "sequence_length": 743,
+    "gc_content": 0.3911290322580645,
+    "protid": "LOTGI10652",
+    "id": 9597528
+  }, {
+    "taxon": {"strain": "", "species": "Lottia gigantea"},
+    "xrefid": "V3ZHX9",
+    "sequence_length": 744,
+    "gc_content": 0.3592841163310962,
+    "protid": "LOTGI18324",
+    "id": 9605200
+  }, {
+    "taxon": {"strain": "", "species": "Nematostella vectensis"},
+    "xrefid": "A7RPH5",
+    "sequence_length": 574,
+    "gc_content": 0.4579710144927536,
+    "protid": "NEMVE05692",
+    "id": 9616082
+  }, {
+    "taxon": {"strain": "", "species": "Nematostella vectensis"},
+    "xrefid": "A7SD95",
+    "sequence_length": 555,
+    "gc_content": 0.4568345323741007,
+    "protid": "NEMVE08579",
+    "id": 9618969
+  }, {
+    "taxon": {"strain": "", "species": "Nematostella vectensis"},
+    "xrefid": "A7SCJ4",
+    "sequence_length": 562,
+    "gc_content": 0.47957371225577267,
+    "protid": "NEMVE13814",
+    "id": 9624204
+  }, {
+    "taxon": {"strain": "", "species": "Mnemiopsis leidyi"},
+    "xrefid": "",
+    "sequence_length": 1104,
+    "gc_content": 0.46726998491704375,
+    "protid": "MNELE12042",
+    "id": 9663161
+  }, {
+    "taxon": {"strain": "", "species": "Trichoplax adhaerens"},
+    "xrefid": "B3RYD9",
+    "sequence_length": 540,
+    "gc_content": 0.39125077017868143,
+    "protid": "TRIAD02820",
+    "id": 9669959
+  }, {
+    "taxon": {"strain": "", "species": "Trichoplax adhaerens"},
+    "xrefid": "B3S4X0",
+    "sequence_length": 728,
+    "gc_content": 0.36488340192043894,
+    "protid": "TRIAD10273",
+    "id": 9677412
+  }, {
+    "taxon": {"strain": "", "species": "Amphimedon queenslandica"},
+    "xrefid": "",
+    "sequence_length": 981,
+    "gc_content": 0.38357094365241007,
+    "protid": "AMPQE13168",
+    "id": 9691773
+  }, {
+    "taxon": {"strain": "", "species": "Amphimedon queenslandica"},
+    "xrefid": "A0A1X7UZG9",
+    "sequence_length": 581,
+    "gc_content": 0.4404352806414662,
+    "protid": "AMPQE20392",
+    "id": 9698997
+  }, {
+    "taxon": {"strain": "", "species": "Amphimedon queenslandica"},
+    "xrefid": "",
+    "sequence_length": 874,
+    "gc_content": 0.35123809523809524,
+    "protid": "AMPQE22298",
+    "id": 9700903
+  }, {
+    "taxon": {"strain": "(strain ATCC 30864)", "species": "Capsaspora owczarzaki "},
+    "xrefid": "A0A0D2VX20",
+    "sequence_length": 543,
+    "gc_content": 0.5741421568627451,
+    "protid": "CAPO303615",
+    "id": 9710684
+  }, {
+    "taxon": {"strain": "", "species": "Creolimax fragrantissima"},
+    "xrefid": "",
+    "sequence_length": 523,
+    "gc_content": 0.4586513994910941,
+    "protid": "CREFR08136",
+    "id": 9723567
+  }, {
+    "taxon": {"strain": "(strain CCMP2755)", "species": "Bigelowiella natans "},
+    "xrefid": "",
+    "sequence_length": 462,
+    "gc_content": 0.49892008639308855,
+    "protid": "BIGNC06351",
+    "id": 9730476
+  }, {
+    "taxon": {"strain": "(strain CCMP2755)", "species": "Bigelowiella natans "},
+    "xrefid": "",
+    "sequence_length": 511,
+    "gc_content": 0.4212239583333333,
+    "protid": "BIGNC17195",
+    "id": 9741320
+  }, {
+    "taxon": {"strain": "(strain CCMP2755)", "species": "Bigelowiella natans "},
+    "xrefid": "",
+    "sequence_length": 804,
+    "gc_content": 0.43768115942028984,
+    "protid": "BIGNC17197",
+    "id": 9741322
+  }, {
+    "taxon": {"strain": "", "species": "Reticulomyxa filosa"},
+    "xrefid": "X6NJD9",
+    "sequence_length": 628,
+    "gc_content": 0.4117647058823529,
+    "protid": "RETFI13955",
+    "id": 9759552
+  }, {
+    "taxon": {"strain": "", "species": "Thalassiosira pseudonana"},
+    "xrefid": "B8BT25",
+    "sequence_length": 419,
+    "gc_content": 0.44285714285714284,
+    "protid": "THAPS00139",
+    "id": 9818278
+  }, {
+    "taxon": {"strain": "", "species": "Thalassiosira pseudonana"},
+    "xrefid": "B8BWW5",
+    "sequence_length": 365,
+    "gc_content": 0.46174863387978143,
+    "protid": "THAPS06187",
+    "id": 9824326
+  }, {
+    "taxon": {"strain": "(strain Emoy2)", "species": "Hyaloperonospora arabidopsidis "},
+    "xrefid": "M4BJT3",
+    "sequence_length": 880,
+    "gc_content": 0.5372682557699584,
+    "protid": "HYAAE07223",
+    "id": 9846007
+  }, {
+    "taxon": {"strain": "(strain Emoy2)", "species": "Hyaloperonospora arabidopsidis "},
+    "xrefid": "M4B4U0",
+    "sequence_length": 735,
+    "gc_content": 0.5588768115942029,
+    "protid": "HYAAE12035",
+    "id": 9850819
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0MUZ3",
+    "sequence_length": 721,
+    "gc_content": 0.5766389658356418,
+    "protid": "PHYIT01086",
+    "id": 9853163
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0N039",
+    "sequence_length": 894,
+    "gc_content": 0.5493482309124768,
+    "protid": "PHYIT02923",
+    "id": 9855000
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0N041",
+    "sequence_length": 785,
+    "gc_content": 0.5267175572519084,
+    "protid": "PHYIT02925",
+    "id": 9855002
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0N0V0",
+    "sequence_length": 606,
+    "gc_content": 0.4975288303130148,
+    "protid": "PHYIT03658",
+    "id": 9855735
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0N0V7",
+    "sequence_length": 547,
+    "gc_content": 0.5371046228710462,
+    "protid": "PHYIT03666",
+    "id": 9855743
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0NHA5",
+    "sequence_length": 627,
+    "gc_content": 0.4723991507430998,
+    "protid": "PHYIT08893",
+    "id": 9860970
+  }, {
+    "taxon": {"strain": "(strain T30-4)", "species": "Phytophthora infestans "},
+    "xrefid": "D0NS83",
+    "sequence_length": 425,
+    "gc_content": 0.5046948356807511,
+    "protid": "PHYIT12535",
+    "id": 9864612
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8B5H1",
+    "sequence_length": 740,
+    "gc_content": 0.5933423301844355,
+    "protid": "PHYNI02950",
+    "id": 9872819
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8D176",
+    "sequence_length": 604,
+    "gc_content": 0.5079889807162534,
+    "protid": "PHYNI08727",
+    "id": 9878596
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8D0U6",
+    "sequence_length": 574,
+    "gc_content": 0.45069605568445475,
+    "protid": "PHYNI08728",
+    "id": 9878597
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8CU90",
+    "sequence_length": 871,
+    "gc_content": 0.5309633027522935,
+    "protid": "PHYNI11011",
+    "id": 9880880
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8CU97",
+    "sequence_length": 839,
+    "gc_content": 0.5555555555555556,
+    "protid": "PHYNI11013",
+    "id": 9880882
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8CMV7",
+    "sequence_length": 909,
+    "gc_content": 0.5043956043956044,
+    "protid": "PHYNI13453",
+    "id": 9883322
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8D7X1",
+    "sequence_length": 441,
+    "gc_content": 0.49278663629460895,
+    "protid": "PHYNI13845",
+    "id": 9883714
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8CSZ8",
+    "sequence_length": 515,
+    "gc_content": 0.4961190168175938,
+    "protid": "PHYNI16507",
+    "id": 9886376
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora nicotianae"},
+    "xrefid": "A0A0W8CSZ4",
+    "sequence_length": 506,
+    "gc_content": 0.5072368421052632,
+    "protid": "PHYNI16508",
+    "id": 9886377
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2L5C3",
+    "sequence_length": 829,
+    "gc_content": 0.5823293172690763,
+    "protid": "PHYPR05757",
+    "id": 9892974
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2KQ06",
+    "sequence_length": 871,
+    "gc_content": 0.5313455657492355,
+    "protid": "PHYPR06381",
+    "id": 9893598
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2GC24",
+    "sequence_length": 893,
+    "gc_content": 0.552945563012677,
+    "protid": "PHYPR06383",
+    "id": 9893600
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2K9I8",
+    "sequence_length": 949,
+    "gc_content": 0.5059649122807017,
+    "protid": "PHYPR06459",
+    "id": 9893676
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2K9Y9",
+    "sequence_length": 567,
+    "gc_content": 0.5346244131455399,
+    "protid": "PHYPR10369",
+    "id": 9897586
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2KA91",
+    "sequence_length": 361,
+    "gc_content": 0.48342541436464087,
+    "protid": "PHYPR10371",
+    "id": 9897588
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2LSY4",
+    "sequence_length": 574,
+    "gc_content": 0.45217391304347826,
+    "protid": "PHYPR19731",
+    "id": 9906948
+  }, {
+    "taxon": {"strain": "", "species": "Phytophthora parasitica"},
+    "xrefid": "W2LSR2",
+    "sequence_length": 604,
+    "gc_content": 0.5068870523415978,
+    "protid": "PHYPR19732",
+    "id": 9906949
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067BJ06",
+    "sequence_length": 216,
+    "gc_content": 0.5944700460829493,
+    "protid": "SAPPC00950",
+    "id": 9913292
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067BS85",
+    "sequence_length": 313,
+    "gc_content": 0.6231422505307855,
+    "protid": "SAPPC01346",
+    "id": 9913688
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067BUH5",
+    "sequence_length": 848,
+    "gc_content": 0.6238712210443659,
+    "protid": "SAPPC02266",
+    "id": 9914608
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067CC80",
+    "sequence_length": 679,
+    "gc_content": 0.6053921568627451,
+    "protid": "SAPPC07987",
+    "id": 9920329
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067CP83",
+    "sequence_length": 684,
+    "gc_content": 0.6194647201946472,
+    "protid": "SAPPC12504",
+    "id": 9924846
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067CNR0",
+    "sequence_length": 566,
+    "gc_content": 0.6219870664315109,
+    "protid": "SAPPC14695",
+    "id": 9927037
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067CS14",
+    "sequence_length": 620,
+    "gc_content": 0.6178207192699946,
+    "protid": "SAPPC17349",
+    "id": 9929691
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067D0J5",
+    "sequence_length": 818,
+    "gc_content": 0.6406186406186406,
+    "protid": "SAPPC19100",
+    "id": 9931442
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067D882",
+    "sequence_length": 682,
+    "gc_content": 0.6515373352855052,
+    "protid": "SAPPC19267",
+    "id": 9931609
+  }, {
+    "taxon": {"strain": "(strain CBS 223.65)", "species": "Saprolegnia parasitica "},
+    "xrefid": "A0A067D9B4",
+    "sequence_length": 678,
+    "gc_content": 0.6519391261659303,
+    "protid": "SAPPC19270",
+    "id": 9931612
+  }, {
+    "taxon": {"strain": "", "species": "Ectocarpus siliculosus"},
+    "xrefid": "D7FS88",
+    "sequence_length": 352,
+    "gc_content": 0.6203966005665722,
+    "protid": "ECTSI01569",
+    "id": 9933764
+  }, {
+    "taxon": {"strain": "", "species": "Aureococcus anophagefferens"},
+    "xrefid": "F0YK79",
+    "sequence_length": 639,
+    "gc_content": 0.7052083333333333,
+    "protid": "AURAN08669",
+    "id": 9953106
+  }, {
+    "taxon": {"strain": "", "species": "Chlamydomonas reinhardtii"},
+    "xrefid": "",
+    "sequence_length": 621,
+    "gc_content": 0.6677384780278671,
+    "protid": "CHLRE12584",
+    "id": 9968246
+  }, {
+    "taxon": {"strain": "", "species": "Chlamydomonas reinhardtii"},
+    "xrefid": "",
+    "sequence_length": 620,
+    "gc_content": 0.667740203972088,
+    "protid": "CHLRE13218",
+    "id": 9968880
+  }, {
+    "taxon": {"strain": "(strain RCC299 / NOUM17 / CCMP2709)", "species": "Micromonas commoda "},
+    "xrefid": "C1E2J6",
+    "sequence_length": 450,
+    "gc_content": 0.6459719142645972,
+    "protid": "MICCC01622",
+    "id": 10013493
+  }, {
+    "taxon": {"strain": "", "species": "Klebsormidium flaccidum"},
+    "xrefid": "A0A1Y1IIU0",
+    "sequence_length": 604,
+    "gc_content": 0.6082644628099173,
+    "protid": "KLEFL02580",
+    "id": 10034829
+  }, {
+    "taxon": {"strain": "", "species": "Klebsormidium flaccidum"},
+    "xrefid": "A0A1Y1I562",
+    "sequence_length": 555,
+    "gc_content": 0.644484412470024,
+    "protid": "KLEFL06014",
+    "id": 10038263
+  }, {
+    "taxon": {"strain": "", "species": "Klebsormidium flaccidum"},
+    "xrefid": "A0A1Y1HT52",
+    "sequence_length": 871,
+    "gc_content": 0.5852446483180428,
+    "protid": "KLEFL09869",
+    "id": 10042118
+  }, {
+    "taxon": {"strain": "subsp. patens", "species": "Physcomitrella patens "},
+    "xrefid": "",
+    "sequence_length": 963,
+    "gc_content": 0.5076071922544951,
+    "protid": "PHYPA06852",
+    "id": 10055354
+  }, {
+    "taxon": {"strain": "subsp. patens", "species": "Physcomitrella patens "},
+    "xrefid": "",
+    "sequence_length": 973,
+    "gc_content": 0.48767967145790553,
+    "protid": "PHYPA25273",
+    "id": 10073775
+  }, {
+    "taxon": {"strain": "subsp. patens", "species": "Physcomitrella patens "},
+    "xrefid": "",
+    "sequence_length": 952,
+    "gc_content": 0.5089192025183631,
+    "protid": "PHYPA28389",
+    "id": 10076891
+  }, {
+    "taxon": {"strain": "subsp. patens", "species": "Physcomitrella patens "},
+    "xrefid": "",
+    "sequence_length": 994,
+    "gc_content": 0.48542713567839196,
+    "protid": "PHYPA30259",
+    "id": 10078761
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3KZU2",
+    "sequence_length": 905,
+    "gc_content": 0.4915378955114054,
+    "protid": "ORYBR01467",
+    "id": 10082744
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3L3T1",
+    "sequence_length": 752,
+    "gc_content": 0.45993802567507747,
+    "protid": "ORYBR02823",
+    "id": 10084100
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3L5K7",
+    "sequence_length": 804,
+    "gc_content": 0.5643892339544514,
+    "protid": "ORYBR03435",
+    "id": 10084712
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3N8U2",
+    "sequence_length": 715,
+    "gc_content": 0.6401303538175046,
+    "protid": "ORYBR07281",
+    "id": 10088558
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3M7Z3",
+    "sequence_length": 774,
+    "gc_content": 0.48301075268817206,
+    "protid": "ORYBR21232",
+    "id": 10102509
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3M934",
+    "sequence_length": 1053,
+    "gc_content": 0.48323845667299176,
+    "protid": "ORYBR21615",
+    "id": 10102892
+  }, {
+    "taxon": {"strain": "", "species": "Oryza brachyantha"},
+    "xrefid": "J3MXS9",
+    "sequence_length": 346,
+    "gc_content": 0.48799231508165225,
+    "protid": "ORYBR29747",
+    "id": 10111024
+  }, {
+    "taxon": {"strain": "", "species": "Oryza glaberrima"},
+    "xrefid": "",
+    "sequence_length": 937,
+    "gc_content": 0.5163701067615658,
+    "protid": "ORYGL02373",
+    "id": 10114957
+  }, {
+    "taxon": {"strain": "", "species": "Oryza glaberrima"},
+    "xrefid": "I1NT28",
+    "sequence_length": 843,
+    "gc_content": 0.5837282780410743,
+    "protid": "ORYGL02901",
+    "id": 10115485
+  }, {
+    "taxon": {"strain": "", "species": "Oryza glaberrima"},
+    "xrefid": "I1R0R3",
+    "sequence_length": 691,
+    "gc_content": 0.6661849710982659,
+    "protid": "ORYGL06628",
+    "id": 10119212
+  }, {
+    "taxon": {"strain": "", "species": "Oryza glaberrima"},
+    "xrefid": "I1PWF8",
+    "sequence_length": 819,
+    "gc_content": 0.4926829268292683,
+    "protid": "ORYGL20214",
+    "id": 10132798
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 893,
+    "gc_content": 0.5052199850857569,
+    "protid": "ORYLO11956",
+    "id": 10156145
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 717,
+    "gc_content": 0.5612813370473537,
+    "protid": "ORYLO14106",
+    "id": 10158295
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 802,
+    "gc_content": 0.46409298464092985,
+    "protid": "ORYLO16970",
+    "id": 10161159
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 746,
+    "gc_content": 0.48148148148148145,
+    "protid": "ORYLO21157",
+    "id": 10165346
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 411,
+    "gc_content": 0.5283171521035599,
+    "protid": "ORYLO22456",
+    "id": 10166645
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 727,
+    "gc_content": 0.4519230769230769,
+    "protid": "ORYLO22734",
+    "id": 10166923
+  }, {
+    "taxon": {"strain": "", "species": "Oryza longistaminata"},
+    "xrefid": "",
+    "sequence_length": 638,
+    "gc_content": 0.6223265519040166,
+    "protid": "ORYLO24244",
+    "id": 10168433
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0FSR9",
+    "sequence_length": 943,
+    "gc_content": 0.5201271186440678,
+    "protid": "ORYNI03509",
+    "id": 10177629
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0FVF2",
+    "sequence_length": 843,
+    "gc_content": 0.5841232227488151,
+    "protid": "ORYNI04236",
+    "id": 10178356
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0J2L8",
+    "sequence_length": 938,
+    "gc_content": 0.6570820021299254,
+    "protid": "ORYNI09182",
+    "id": 10183302
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0J8C6",
+    "sequence_length": 792,
+    "gc_content": 0.496427070197562,
+    "protid": "ORYNI10729",
+    "id": 10184849
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0HIP6",
+    "sequence_length": 905,
+    "gc_content": 0.5025754231052244,
+    "protid": "ORYNI26665",
+    "id": 10200785
+  }, {
+    "taxon": {"strain": "", "species": "Oryza nivara"},
+    "xrefid": "A0A0E0IE42",
+    "sequence_length": 951,
+    "gc_content": 0.5199579831932774,
+    "protid": "ORYNI35100",
+    "id": 10209220
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0JID4",
+    "sequence_length": 905,
+    "gc_content": 0.4966887417218543,
+    "protid": "ORYPU01493",
+    "id": 10213360
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0JNN7",
+    "sequence_length": 937,
+    "gc_content": 0.5159914712153518,
+    "protid": "ORYPU02961",
+    "id": 10214828
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0JQP6",
+    "sequence_length": 843,
+    "gc_content": 0.5774091627172195,
+    "protid": "ORYPU03504",
+    "id": 10215371
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0MG12",
+    "sequence_length": 846,
+    "gc_content": 0.637150728059819,
+    "protid": "ORYPU07613",
+    "id": 10219480
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0MG15",
+    "sequence_length": 940,
+    "gc_content": 0.6478923131420474,
+    "protid": "ORYPU07616",
+    "id": 10219483
+  }, {
+    "taxon": {"strain": "", "species": "Oryza punctata"},
+    "xrefid": "A0A0E0L3K5",
+    "sequence_length": 838,
+    "gc_content": 0.4958283671036949,
+    "protid": "ORYPU22228",
+    "id": 10234095
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0MW72",
+    "sequence_length": 910,
+    "gc_content": 0.5016465422612514,
+    "protid": "ORYRU01723",
+    "id": 10245951
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0N242",
+    "sequence_length": 973,
+    "gc_content": 0.5232717316906229,
+    "protid": "ORYRU03393",
+    "id": 10247621
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0N4M2",
+    "sequence_length": 843,
+    "gc_content": 0.5841232227488151,
+    "protid": "ORYRU04081",
+    "id": 10248309
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0R9C8",
+    "sequence_length": 930,
+    "gc_content": 0.6519871106337272,
+    "protid": "ORYRU09043",
+    "id": 10253271
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0PNP1",
+    "sequence_length": 828,
+    "gc_content": 0.4925613188580619,
+    "protid": "ORYRU26384",
+    "id": 10270612
+  }, {
+    "taxon": {"strain": "", "species": "Oryza rufipogon"},
+    "xrefid": "A0A0E0PQ84",
+    "sequence_length": 951,
+    "gc_content": 0.5199579831932774,
+    "protid": "ORYRU26822",
+    "id": 10271050
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "RBOHB_ORYSI",
+    "sequence_length": 905,
+    "gc_content": 0.5014716703458425,
+    "protid": "ORYSI01827",
+    "id": 10284451
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "B8A924",
+    "sequence_length": 532,
+    "gc_content": 0.43964978111319575,
+    "protid": "ORYSI03495",
+    "id": 10286119
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "A2WWR0",
+    "sequence_length": 843,
+    "gc_content": 0.5837282780410743,
+    "protid": "ORYSI04162",
+    "id": 10286786
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "B8BKW6",
+    "sequence_length": 983,
+    "gc_content": 0.6500677506775068,
+    "protid": "ORYSI08906",
+    "id": 10291530
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "B8AZ16",
+    "sequence_length": 819,
+    "gc_content": 0.4926829268292683,
+    "protid": "ORYSI25851",
+    "id": 10308475
+  }, {
+    "taxon": {"strain": "subsp. indica", "species": "Oryza sativa "},
+    "xrefid": "A2Y6R3",
+    "sequence_length": 951,
+    "gc_content": 0.5199579831932774,
+    "protid": "ORYSI26279",
+    "id": 10308903
+  }, {
+    "taxon": {"strain": "subsp. japonica", "species": "Oryza sativa "},
+    "xrefid": "RBOHB_ORYSJ",
+    "sequence_length": 905,
+    "gc_content": 0.5022075055187638,
+    "protid": "ORYSJ01573",
+    "id": 10324561
+  }, {
+    "taxon": {"strain": "subsp. japonica", "species": "Oryza sativa "},
+    "xrefid": "A0A0P0V7W2",
+    "sequence_length": 536,
+    "gc_content": 0.4388578522656735,
+    "protid": "ORYSJ03058",
+    "id": 10326046
+  }, {
+    "taxon": {"strain": "subsp. japonica", "species": "Oryza sativa "},
+    "xrefid": "Q8S1T0",
+    "sequence_length": 843,
+    "gc_content": 0.5841232227488151,
+    "protid": "ORYSJ03717",
+    "id": 10326705
+  }, {
+    "taxon": {"strain": "subsp. japonica", "species": "Oryza sativa "},
+    "xrefid": "Q0DHH6",
+    "sequence_length": 819,
+    "gc_content": 0.49308943089430896,
+    "protid": "ORYSJ23616",
+    "id": 10346604
+  }, {
+    "taxon": {"strain": "subsp. japonica", "species": "Oryza sativa "},
+    "xrefid": "Q65XC8",
+    "sequence_length": 951,
+    "gc_content": 0.5206582633053222,
+    "protid": "ORYSJ24018",
+    "id": 10347006
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1HF92",
+    "sequence_length": 901,
+    "gc_content": 0.47560975609756095,
+    "protid": "BRADI09055",
+    "id": 10366268
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1HHB9",
+    "sequence_length": 989,
+    "gc_content": 0.5383838383838384,
+    "protid": "BRADI09671",
+    "id": 10366884
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1HIL0",
+    "sequence_length": 835,
+    "gc_content": 0.5103668261562998,
+    "protid": "BRADI10035",
+    "id": 10367248
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1HR95",
+    "sequence_length": 943,
+    "gc_content": 0.5240112994350282,
+    "protid": "BRADI12330",
+    "id": 10369543
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1HT51",
+    "sequence_length": 845,
+    "gc_content": 0.5728920409771474,
+    "protid": "BRADI12876",
+    "id": 10370089
+  }, {
+    "taxon": {"strain": "", "species": "Brachypodium distachyon"},
+    "xrefid": "I1ILC5",
+    "sequence_length": 924,
+    "gc_content": 0.6457657657657657,
+    "protid": "BRADI21341",
+    "id": 10378554
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 832,
+    "gc_content": 0.5248397435897436,
+    "protid": "HORVD08933",
+    "id": 10392825
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 602,
+    "gc_content": 0.4579180509413068,
+    "protid": "HORVD12378",
+    "id": 10396270
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 692,
+    "gc_content": 0.6069364161849711,
+    "protid": "HORVD12389",
+    "id": 10396281
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 867,
+    "gc_content": 0.512879661668589,
+    "protid": "HORVD12711",
+    "id": 10396603
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 515,
+    "gc_content": 0.574757281553398,
+    "protid": "HORVD13539",
+    "id": 10397431
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 860,
+    "gc_content": 0.6360465116279069,
+    "protid": "HORVD17146",
+    "id": 10401038
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 845,
+    "gc_content": 0.5234714003944774,
+    "protid": "HORVD17376",
+    "id": 10401268
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 351,
+    "gc_content": 0.48338081671415006,
+    "protid": "HORVD18539",
+    "id": 10402431
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 720,
+    "gc_content": 0.6592592592592592,
+    "protid": "HORVD18963",
+    "id": 10402855
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 906,
+    "gc_content": 0.4841795437821928,
+    "protid": "HORVD21272",
+    "id": 10405164
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 726,
+    "gc_content": 0.4885215794306703,
+    "protid": "HORVD21995",
+    "id": 10405887
+  }, {
+    "taxon": {"strain": "", "species": "Hordeum vulgare var. distichon"},
+    "xrefid": "",
+    "sequence_length": 807,
+    "gc_content": 0.5650557620817844,
+    "protid": "HORVD22599",
+    "id": 10406491
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "N1QPG8",
+    "sequence_length": 669,
+    "gc_content": 0.6606965174129353,
+    "protid": "AEGTA11759",
+    "id": 10424865
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "M8CET7",
+    "sequence_length": 946,
+    "gc_content": 0.49137627595916933,
+    "protid": "AEGTA15562",
+    "id": 10428668
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "M8BTM2",
+    "sequence_length": 717,
+    "gc_content": 0.6323119777158774,
+    "protid": "AEGTA16901",
+    "id": 10430007
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "R7WA75",
+    "sequence_length": 707,
+    "gc_content": 0.4646892655367232,
+    "protid": "AEGTA17947",
+    "id": 10431053
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "M8CU28",
+    "sequence_length": 726,
+    "gc_content": 0.47455295735900965,
+    "protid": "AEGTA18102",
+    "id": 10431208
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "M8BVZ0",
+    "sequence_length": 797,
+    "gc_content": 0.5267335004177109,
+    "protid": "AEGTA24871",
+    "id": 10437977
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "M8CAL5",
+    "sequence_length": 731,
+    "gc_content": 0.5701275045537341,
+    "protid": "AEGTA26371",
+    "id": 10439477
+  }, {
+    "taxon": {"strain": "", "species": "Aegilops tauschii"},
+    "xrefid": "N1R2B9",
+    "sequence_length": 726,
+    "gc_content": 0.4828060522696011,
+    "protid": "AEGTA27913",
+    "id": 10441019
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5S7U3",
+    "sequence_length": 822,
+    "gc_content": 0.48521668691778047,
+    "protid": "WHEAT16482",
+    "id": 10463383
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5VTM3",
+    "sequence_length": 734,
+    "gc_content": 0.48435374149659866,
+    "protid": "WHEAT18276",
+    "id": 10465177
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5YD94",
+    "sequence_length": 723,
+    "gc_content": 0.6620626151012892,
+    "protid": "WHEAT26696",
+    "id": 10473597
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5S963",
+    "sequence_length": 890,
+    "gc_content": 0.5334829779274224,
+    "protid": "WHEAT30072",
+    "id": 10476973
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D6RXH4",
+    "sequence_length": 847,
+    "gc_content": 0.5184748427672956,
+    "protid": "WHEAT41650",
+    "id": 10488551
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5SS35",
+    "sequence_length": 888,
+    "gc_content": 0.5324334458192725,
+    "protid": "WHEAT46247",
+    "id": 10493148
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5WFM4",
+    "sequence_length": 687,
+    "gc_content": 0.564922480620155,
+    "protid": "WHEAT50746",
+    "id": 10497647
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "W5A2Z9",
+    "sequence_length": 656,
+    "gc_content": 0.4591577879249112,
+    "protid": "WHEAT52556",
+    "id": 10499457
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5XYR5",
+    "sequence_length": 666,
+    "gc_content": 0.6306846576711644,
+    "protid": "WHEAT52654",
+    "id": 10499555
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5XYY0",
+    "sequence_length": 847,
+    "gc_content": 0.5189873417721519,
+    "protid": "WHEAT53644",
+    "id": 10500545
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5YH47",
+    "sequence_length": 919,
+    "gc_content": 0.6565217391304348,
+    "protid": "WHEAT58983",
+    "id": 10505884
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5STA3",
+    "sequence_length": 823,
+    "gc_content": 0.48624595469255666,
+    "protid": "WHEAT61602",
+    "id": 10508503
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5VJG8",
+    "sequence_length": 901,
+    "gc_content": 0.4844789356984479,
+    "protid": "WHEAT77485",
+    "id": 10524386
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5VAI0",
+    "sequence_length": 851,
+    "gc_content": 0.5845070422535211,
+    "protid": "WHEAT77782",
+    "id": 10524683
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5XL48",
+    "sequence_length": 650,
+    "gc_content": 0.6241679467485919,
+    "protid": "WHEAT79225",
+    "id": 10526126
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5SUX2",
+    "sequence_length": 968,
+    "gc_content": 0.5455796353629171,
+    "protid": "WHEAT80408",
+    "id": 10527309
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5VCJ0",
+    "sequence_length": 945,
+    "gc_content": 0.5496828752642706,
+    "protid": "WHEAT97795",
+    "id": 10544696
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5RWU6",
+    "sequence_length": 832,
+    "gc_content": 0.5294117647058824,
+    "protid": "WHEAT100137",
+    "id": 10547038
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5W7E2",
+    "sequence_length": 850,
+    "gc_content": 0.581668625146886,
+    "protid": "WHEAT100330",
+    "id": 10547231
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5RX89",
+    "sequence_length": 961,
+    "gc_content": 0.542966042966043,
+    "protid": "WHEAT105102",
+    "id": 10552003
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5WMI6",
+    "sequence_length": 726,
+    "gc_content": 0.48372306281522237,
+    "protid": "WHEAT117391",
+    "id": 10564292
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D5YPE9",
+    "sequence_length": 847,
+    "gc_content": 0.5169025157232704,
+    "protid": "WHEAT117457",
+    "id": 10564358
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "A0A1D6RUM1",
+    "sequence_length": 375,
+    "gc_content": 0.4946808510638298,
+    "protid": "WHEAT120072",
+    "id": 10566973
+  }, {
+    "taxon": {"strain": "", "species": "Triticum aestivum"},
+    "xrefid": "W4ZM60",
+    "sequence_length": 792,
+    "gc_content": 0.48886086591004624,
+    "protid": "WHEAT127583",
+    "id": 10574484
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "M7Y9F1",
+    "sequence_length": 843,
+    "gc_content": 0.5201421800947867,
+    "protid": "TRIUA05334",
+    "id": 10590884
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "M7ZKJ1",
+    "sequence_length": 731,
+    "gc_content": 0.5323315118397086,
+    "protid": "TRIUA07453",
+    "id": 10593003
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "M7ZVP1",
+    "sequence_length": 624,
+    "gc_content": 0.6293333333333333,
+    "protid": "TRIUA10181",
+    "id": 10595731
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "M7ZS16",
+    "sequence_length": 805,
+    "gc_content": 0.4718775847808106,
+    "protid": "TRIUA10596",
+    "id": 10596146
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "T1LFI6",
+    "sequence_length": 468,
+    "gc_content": 0.48646723646723644,
+    "protid": "TRIUA13650",
+    "id": 10599200
+  }, {
+    "taxon": {"strain": "", "species": "Triticum urartu"},
+    "xrefid": "M8A5L8",
+    "sequence_length": 707,
+    "gc_content": 0.4623352165725047,
+    "protid": "TRIUA14916",
+    "id": 10600466
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 812,
+    "gc_content": 0.4879048790487905,
+    "protid": "ERATE02148",
+    "id": 10620333
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 716,
+    "gc_content": 0.5383542538354253,
+    "protid": "ERATE02270",
+    "id": 10620455
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 658,
+    "gc_content": 0.6079919069296914,
+    "protid": "ERATE03053",
+    "id": 10621238
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 350,
+    "gc_content": 0.4681861348528015,
+    "protid": "ERATE07221",
+    "id": 10625406
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 452,
+    "gc_content": 0.5184365781710915,
+    "protid": "ERATE17313",
+    "id": 10635498
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 899,
+    "gc_content": 0.4948148148148148,
+    "protid": "ERATE18244",
+    "id": 10636429
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 1132,
+    "gc_content": 0.47896440129449835,
+    "protid": "ERATE21051",
+    "id": 10639236
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 853,
+    "gc_content": 0.5011709601873536,
+    "protid": "ERATE26350",
+    "id": 10644535
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 895,
+    "gc_content": 0.4732142857142857,
+    "protid": "ERATE26940",
+    "id": 10645125
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 1133,
+    "gc_content": 0.4656084656084656,
+    "protid": "ERATE28452",
+    "id": 10646637
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 895,
+    "gc_content": 0.4720982142857143,
+    "protid": "ERATE28453",
+    "id": 10646638
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 832,
+    "gc_content": 0.664265706282513,
+    "protid": "ERATE29909",
+    "id": 10648094
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 814,
+    "gc_content": 0.5124744376278119,
+    "protid": "ERATE31661",
+    "id": 10649846
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 761,
+    "gc_content": 0.4844502847130968,
+    "protid": "ERATE36515",
+    "id": 10654700
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 798,
+    "gc_content": 0.5511055486024197,
+    "protid": "ERATE39251",
+    "id": 10657436
+  }, {
+    "taxon": {"strain": "", "species": "Eragrostis tef"},
+    "xrefid": "",
+    "sequence_length": 922,
+    "gc_content": 0.542795232936078,
+    "protid": "ERATE41311",
+    "id": 10659496
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 566,
+    "gc_content": 0.4432686654908877,
+    "protid": "SORBI00042",
+    "id": 10659720
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 713,
+    "gc_content": 0.453781512605042,
+    "protid": "SORBI01349",
+    "id": 10661027
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 784,
+    "gc_content": 0.524416135881104,
+    "protid": "SORBI09147",
+    "id": 10668825
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 932,
+    "gc_content": 0.5185979971387696,
+    "protid": "SORBI09265",
+    "id": 10668943
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 550,
+    "gc_content": 0.6061705989110708,
+    "protid": "SORBI22105",
+    "id": 10681783
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 896,
+    "gc_content": 0.4782608695652174,
+    "protid": "SORBI32745",
+    "id": 10692423
+  }, {
+    "taxon": {"strain": "", "species": "Sorghum bicolor"},
+    "xrefid": "",
+    "sequence_length": 936,
+    "gc_content": 0.6659551760939167,
+    "protid": "SORBI33732",
+    "id": 10693410
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 624,
+    "gc_content": 0.46613333333333334,
+    "protid": "MAIZE02289",
+    "id": 10697414
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "A0A1D6F6A5",
+    "sequence_length": 948,
+    "gc_content": 0.6631541974007727,
+    "protid": "MAIZE14282",
+    "id": 10709407
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 976,
+    "gc_content": 0.6557488911634255,
+    "protid": "MAIZE14284",
+    "id": 10709409
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 882,
+    "gc_content": 0.6489241223103058,
+    "protid": "MAIZE14286",
+    "id": 10709411
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 921,
+    "gc_content": 0.48156182212581344,
+    "protid": "MAIZE16088",
+    "id": 10711213
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "A0A1D6MTM7",
+    "sequence_length": 842,
+    "gc_content": 0.542506919731119,
+    "protid": "MAIZE16324",
+    "id": 10711449
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 852,
+    "gc_content": 0.5670183665494334,
+    "protid": "MAIZE17760",
+    "id": 10712885
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "A0A1D6ND49",
+    "sequence_length": 943,
+    "gc_content": 0.515183615819209,
+    "protid": "MAIZE18303",
+    "id": 10713428
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "K7U3R2",
+    "sequence_length": 932,
+    "gc_content": 0.6763129689174705,
+    "protid": "MAIZE22679",
+    "id": 10717804
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "A0A1D6MAD7",
+    "sequence_length": 948,
+    "gc_content": 0.52019669827889,
+    "protid": "MAIZE32178",
+    "id": 10727303
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "",
+    "sequence_length": 346,
+    "gc_content": 0.5072046109510087,
+    "protid": "MAIZE34269",
+    "id": 10729394
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "K7V0F9",
+    "sequence_length": 897,
+    "gc_content": 0.4725315515961396,
+    "protid": "MAIZE37011",
+    "id": 10732136
+  }, {
+    "taxon": {"strain": "", "species": "Zea mays"},
+    "xrefid": "K7UWK1",
+    "sequence_length": 822,
+    "gc_content": 0.5532604293236127,
+    "protid": "MAIZE37081",
+    "id": 10732206
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3ZUT9",
+    "sequence_length": 346,
+    "gc_content": 0.4860710854947166,
+    "protid": "SETIT06231",
+    "id": 10744982
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3Z3I9",
+    "sequence_length": 963,
+    "gc_content": 0.5314661134163209,
+    "protid": "SETIT10296",
+    "id": 10749047
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3XEC7",
+    "sequence_length": 899,
+    "gc_content": 0.47703703703703704,
+    "protid": "SETIT17485",
+    "id": 10756236
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3XRY1",
+    "sequence_length": 773,
+    "gc_content": 0.5361757105943152,
+    "protid": "SETIT17678",
+    "id": 10756429
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3XE76",
+    "sequence_length": 958,
+    "gc_content": 0.5255474452554745,
+    "protid": "SETIT18981",
+    "id": 10757732
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3XEH3",
+    "sequence_length": 848,
+    "gc_content": 0.5586965056929721,
+    "protid": "SETIT19641",
+    "id": 10758392
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3YLF5",
+    "sequence_length": 772,
+    "gc_content": 0.47089262613195343,
+    "protid": "SETIT21407",
+    "id": 10760158
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3ZL81",
+    "sequence_length": 927,
+    "gc_content": 0.6641522988505747,
+    "protid": "SETIT28044",
+    "id": 10766795
+  }, {
+    "taxon": {"strain": "", "species": "Setaria italica"},
+    "xrefid": "K3ZH79",
+    "sequence_length": 931,
+    "gc_content": 0.6655937052932761,
+    "protid": "SETIT28176",
+    "id": 10766927
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 834,
+    "gc_content": 0.6199600798403193,
+    "protid": "MUSAC02129",
+    "id": 10776504
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 834,
+    "gc_content": 0.5932135728542914,
+    "protid": "MUSAC13262",
+    "id": 10787637
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 722,
+    "gc_content": 0.44352236053480865,
+    "protid": "MUSAC13490",
+    "id": 10787865
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 844,
+    "gc_content": 0.5218934911242603,
+    "protid": "MUSAC20516",
+    "id": 10794891
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 919,
+    "gc_content": 0.6007246376811595,
+    "protid": "MUSAC21366",
+    "id": 10795741
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 521,
+    "gc_content": 0.5970625798212005,
+    "protid": "MUSAC21861",
+    "id": 10796236
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 871,
+    "gc_content": 0.5592507645259939,
+    "protid": "MUSAC23829",
+    "id": 10798204
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 556,
+    "gc_content": 0.5451825254338719,
+    "protid": "MUSAC23994",
+    "id": 10798369
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 408,
+    "gc_content": 0.5965770171149144,
+    "protid": "MUSAC27559",
+    "id": 10801934
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 861,
+    "gc_content": 0.6051817478731631,
+    "protid": "MUSAC28010",
+    "id": 10802385
+  }, {
+    "taxon": {"strain": "", "species": "Musa acuminata"},
+    "xrefid": "",
+    "sequence_length": 892,
+    "gc_content": 0.5864128406121687,
+    "protid": "MUSAC29562",
+    "id": 10803937
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0RF57",
+    "sequence_length": 844,
+    "gc_content": 0.5218934911242603,
+    "protid": "MUSAM03204",
+    "id": 10814018
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0RHL0",
+    "sequence_length": 919,
+    "gc_content": 0.6007246376811595,
+    "protid": "MUSAM04054",
+    "id": 10814868
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0RJ06",
+    "sequence_length": 521,
+    "gc_content": 0.5970625798212005,
+    "protid": "MUSAM04549",
+    "id": 10815363
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0S9X5",
+    "sequence_length": 834,
+    "gc_content": 0.6199600798403193,
+    "protid": "MUSAM10772",
+    "id": 10821586
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0T222",
+    "sequence_length": 834,
+    "gc_content": 0.5932135728542914,
+    "protid": "MUSAM20250",
+    "id": 10831064
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0T2P9",
+    "sequence_length": 722,
+    "gc_content": 0.44352236053480865,
+    "protid": "MUSAM20478",
+    "id": 10831292
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0T674",
+    "sequence_length": 408,
+    "gc_content": 0.5965770171149144,
+    "protid": "MUSAM21702",
+    "id": 10832516
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0T7H5",
+    "sequence_length": 861,
+    "gc_content": 0.6051817478731631,
+    "protid": "MUSAM22153",
+    "id": 10832967
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0TBY0",
+    "sequence_length": 892,
+    "gc_content": 0.5864128406121687,
+    "protid": "MUSAM23704",
+    "id": 10834518
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0TXQ4",
+    "sequence_length": 871,
+    "gc_content": 0.5592507645259939,
+    "protid": "MUSAM30966",
+    "id": 10841780
+  }, {
+    "taxon": {"strain": "subsp. malaccensis", "species": "Musa acuminata "},
+    "xrefid": "M0TY69",
+    "sequence_length": 556,
+    "gc_content": 0.5451825254338719,
+    "protid": "MUSAM31131",
+    "id": 10841945
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4B0Z7",
+    "sequence_length": 865,
+    "gc_content": 0.41570438799076215,
+    "protid": "SOLLC03100",
+    "id": 10850353
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4DAY7",
+    "sequence_length": 816,
+    "gc_content": 0.3810689514483884,
+    "protid": "SOLLC09133",
+    "id": 10856386
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4BLU9",
+    "sequence_length": 938,
+    "gc_content": 0.4334398296059638,
+    "protid": "SOLLC17822",
+    "id": 10865075
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4BZV6",
+    "sequence_length": 624,
+    "gc_content": 0.40426666666666666,
+    "protid": "SOLLC22393",
+    "id": 10869646
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4C842",
+    "sequence_length": 857,
+    "gc_content": 0.40559440559440557,
+    "protid": "SOLLC25288",
+    "id": 10872541
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4C9S2",
+    "sequence_length": 830,
+    "gc_content": 0.39510629763337346,
+    "protid": "SOLLC25869",
+    "id": 10873122
+  }, {
+    "taxon": {"strain": "", "species": "Solanum lycopersicum"},
+    "xrefid": "K4CPG5",
+    "sequence_length": 963,
+    "gc_content": 0.4405255878284924,
+    "protid": "SOLLC31033",
+    "id": 10878286
+  }, {
+    "taxon": {"strain": "", "species": "Solanum tuberosum"},
+    "xrefid": "Q948T9",
+    "sequence_length": 867,
+    "gc_content": 0.41935483870967744,
+    "protid": "SOLTU05303",
+    "id": 10886258
+  }, {
+    "taxon": {"strain": "", "species": "Solanum tuberosum"},
+    "xrefid": "M1B9G6",
+    "sequence_length": 776,
+    "gc_content": 0.3891033891033891,
+    "protid": "SOLTU12209",
+    "id": 10893164
+  }, {
+    "taxon": {"strain": "", "species": "Solanum tuberosum"},
+    "xrefid": "Q2HXL0",
+    "sequence_length": 938,
+    "gc_content": 0.4334398296059638,
+    "protid": "SOLTU22168",
+    "id": 10903123
+  }, {
+    "taxon": {"strain": "", "species": "Solanum tuberosum"},
+    "xrefid": "M1CEX9",
+    "sequence_length": 458,
+    "gc_content": 0.4139433551198257,
+    "protid": "SOLTU28013",
+    "id": 10908968
+  }, {
+    "taxon": {"strain": "", "species": "Solanum tuberosum"},
+    "xrefid": "M1CZG4",
+    "sequence_length": 834,
+    "gc_content": 0.39840319361277443,
+    "protid": "SOLTU32349",
+    "id": 10913304
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 743,
+    "gc_content": 0.44086021505376344,
+    "protid": "LOTJA14889",
+    "id": 10937640
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 727,
+    "gc_content": 0.40613553113553114,
+    "protid": "LOTJA17412",
+    "id": 10940163
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 728,
+    "gc_content": 0.43209876543209874,
+    "protid": "LOTJA22765",
+    "id": 10945516
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 800,
+    "gc_content": 0.43875,
+    "protid": "LOTJA30858",
+    "id": 10953609
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 927,
+    "gc_content": 0.444683908045977,
+    "protid": "LOTJA32508",
+    "id": 10955259
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 948,
+    "gc_content": 0.46259220231822973,
+    "protid": "LOTJA32677",
+    "id": 10955428
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 892,
+    "gc_content": 0.45987308697275103,
+    "protid": "LOTJA34934",
+    "id": 10957685
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 795,
+    "gc_content": 0.41959798994974873,
+    "protid": "LOTJA34935",
+    "id": 10957686
+  }, {
+    "taxon": {"strain": "", "species": "Lotus japonicus"},
+    "xrefid": "",
+    "sequence_length": 886,
+    "gc_content": 0.4592258549417512,
+    "protid": "LOTJA38142",
+    "id": 10960893
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1LGC3",
+    "sequence_length": 927,
+    "gc_content": 0.46839080459770116,
+    "protid": "SOYBN02609",
+    "id": 10964805
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1MT65",
+    "sequence_length": 821,
+    "gc_content": 0.4278183292781833,
+    "protid": "SOYBN08183",
+    "id": 10970379
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "K7KME9",
+    "sequence_length": 820,
+    "gc_content": 0.43767762890783596,
+    "protid": "SOYBN10020",
+    "id": 10972216
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1K561",
+    "sequence_length": 893,
+    "gc_content": 0.4552572706935123,
+    "protid": "SOYBN11944",
+    "id": 10974140
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1K6D2",
+    "sequence_length": 941,
+    "gc_content": 0.4734607218683652,
+    "protid": "SOYBN12333",
+    "id": 10974529
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1KJX2",
+    "sequence_length": 859,
+    "gc_content": 0.40581395348837207,
+    "protid": "SOYBN17309",
+    "id": 10979505
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "K7N5A2",
+    "sequence_length": 889,
+    "gc_content": 0.4797752808988764,
+    "protid": "SOYBN20992",
+    "id": 10983188
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1KP09",
+    "sequence_length": 888,
+    "gc_content": 0.4536932883389576,
+    "protid": "SOYBN23960",
+    "id": 10986156
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1KPG0",
+    "sequence_length": 941,
+    "gc_content": 0.4734607218683652,
+    "protid": "SOYBN24087",
+    "id": 10986283
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1JRB1",
+    "sequence_length": 885,
+    "gc_content": 0.4721595184349135,
+    "protid": "SOYBN29853",
+    "id": 10992049
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1JXT0",
+    "sequence_length": 928,
+    "gc_content": 0.45174022246142803,
+    "protid": "SOYBN32032",
+    "id": 10994228
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1NBY2",
+    "sequence_length": 887,
+    "gc_content": 0.4752252252252252,
+    "protid": "SOYBN37048",
+    "id": 10999244
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1KBU7",
+    "sequence_length": 941,
+    "gc_content": 0.45612172682236374,
+    "protid": "SOYBN38943",
+    "id": 11001139
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1LBA5",
+    "sequence_length": 888,
+    "gc_content": 0.4754405699287589,
+    "protid": "SOYBN44728",
+    "id": 11006924
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1JAA1",
+    "sequence_length": 927,
+    "gc_content": 0.46839080459770116,
+    "protid": "SOYBN51427",
+    "id": 11013623
+  }, {
+    "taxon": {"strain": "", "species": "Glycine max"},
+    "xrefid": "I1N2F7",
+    "sequence_length": 853,
+    "gc_content": 0.4059328649492584,
+    "protid": "SOYBN53418",
+    "id": 11015614
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "G7LGI5",
+    "sequence_length": 898,
+    "gc_content": 0.42825361512791993,
+    "protid": "MEDTR08741",
+    "id": 11025543
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "G7I8P3",
+    "sequence_length": 885,
+    "gc_content": 0.42325056433408575,
+    "protid": "MEDTR12059",
+    "id": 11028861
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "",
+    "sequence_length": 870,
+    "gc_content": 0.3781094527363184,
+    "protid": "MEDTR20489",
+    "id": 11037291
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "Q5ENY3",
+    "sequence_length": 895,
+    "gc_content": 0.42038690476190477,
+    "protid": "MEDTR23530",
+    "id": 11040332
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "G7J2Q9",
+    "sequence_length": 917,
+    "gc_content": 0.40631808278867104,
+    "protid": "MEDTR35559",
+    "id": 11052361
+  }, {
+    "taxon": {"strain": "", "species": "Medicago truncatula"},
+    "xrefid": "G7J2R2",
+    "sequence_length": 923,
+    "gc_content": 0.40440115440115443,
+    "protid": "MEDTR35562",
+    "id": 11052364
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "",
+    "sequence_length": 683,
+    "gc_content": 0.39717348927875246,
+    "protid": "MANES03530",
+    "id": 11063288
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "",
+    "sequence_length": 910,
+    "gc_content": 0.44310281741675817,
+    "protid": "MANES05068",
+    "id": 11064826
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "",
+    "sequence_length": 884,
+    "gc_content": 0.4354048964218456,
+    "protid": "MANES06504",
+    "id": 11066262
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "V9HYZ7",
+    "sequence_length": 908,
+    "gc_content": 0.4536120278694536,
+    "protid": "MANES07292",
+    "id": 11067050
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "",
+    "sequence_length": 932,
+    "gc_content": 0.45087531261164704,
+    "protid": "MANES10640",
+    "id": 11070398
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "V9HZ00",
+    "sequence_length": 944,
+    "gc_content": 0.44761904761904764,
+    "protid": "MANES18979",
+    "id": 11078737
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "V9HYS7",
+    "sequence_length": 914,
+    "gc_content": 0.46375227686703097,
+    "protid": "MANES19293",
+    "id": 11079051
+  }, {
+    "taxon": {"strain": "", "species": "Manihot esculenta"},
+    "xrefid": "V9HYZ9",
+    "sequence_length": 883,
+    "gc_content": 0.4098793363499246,
+    "protid": "MANES30340",
+    "id": 11090098
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9IG58",
+    "sequence_length": 852,
+    "gc_content": 0.41617819460726846,
+    "protid": "POPTR05055",
+    "id": 11097550
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9I440",
+    "sequence_length": 909,
+    "gc_content": 0.44468864468864466,
+    "protid": "POPTR07864",
+    "id": 11100359
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9ICD3",
+    "sequence_length": 915,
+    "gc_content": 0.45087336244541487,
+    "protid": "POPTR12234",
+    "id": 11104729
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "",
+    "sequence_length": 926,
+    "gc_content": 0.4361740381157857,
+    "protid": "POPTR22701",
+    "id": 11115196
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9GYU0",
+    "sequence_length": 926,
+    "gc_content": 0.44084861560589717,
+    "protid": "POPTR22953",
+    "id": 11115448
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9N4H8",
+    "sequence_length": 876,
+    "gc_content": 0.43329532497149376,
+    "protid": "POPTR31317",
+    "id": 11123812
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9HCK1",
+    "sequence_length": 846,
+    "gc_content": 0.4195198740653286,
+    "protid": "POPTR34759",
+    "id": 11127254
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "U5GT54",
+    "sequence_length": 949,
+    "gc_content": 0.44,
+    "protid": "POPTR37561",
+    "id": 11130056
+  }, {
+    "taxon": {"strain": "", "species": "Populus trichocarpa"},
+    "xrefid": "B9GMW7",
+    "sequence_length": 926,
+    "gc_content": 0.44732110751528226,
+    "protid": "POPTR37829",
+    "id": 11130324
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5WCW1",
+    "sequence_length": 964,
+    "gc_content": 0.49222797927461137,
+    "protid": "PRUPE01705",
+    "id": 11135497
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5WEF2",
+    "sequence_length": 941,
+    "gc_content": 0.4631988676574664,
+    "protid": "PRUPE02002",
+    "id": 11135794
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5WCP3",
+    "sequence_length": 716,
+    "gc_content": 0.4216643421664342,
+    "protid": "PRUPE02628",
+    "id": 11136420
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5WKJ2",
+    "sequence_length": 608,
+    "gc_content": 0.42653508771929827,
+    "protid": "PRUPE15515",
+    "id": 11149307
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5WLR0",
+    "sequence_length": 893,
+    "gc_content": 0.45600298284862045,
+    "protid": "PRUPE17862",
+    "id": 11151654
+  }, {
+    "taxon": {"strain": "", "species": "Prunus persica"},
+    "xrefid": "M5XM37",
+    "sequence_length": 971,
+    "gc_content": 0.5099451303155007,
+    "protid": "PRUPE23761",
+    "id": 11157553
+  }, {
+    "taxon": {"strain": "", "species": "Arabis alpina"},
+    "xrefid": "A0A087HEC2",
+    "sequence_length": 945,
+    "gc_content": 0.3928823114869627,
+    "protid": "ARAAL02664",
+    "id": 11163937
+  }, {
+    "taxon": {"strain": "", "species": "Arabis alpina"},
+    "xrefid": "A0A087H3P9",
+    "sequence_length": 900,
+    "gc_content": 0.46466888642249354,
+    "protid": "ARAAL08826",
+    "id": 11170099
+  }, {
+    "taxon": {"strain": "", "species": "Arabis alpina"},
+    "xrefid": "A0A087GVP8",
+    "sequence_length": 857,
+    "gc_content": 0.45454545454545453,
+    "protid": "ARAAL10263",
+    "id": 11171536
+  }, {
+    "taxon": {"strain": "", "species": "Arabis alpina"},
+    "xrefid": "A0A087GZD0",
+    "sequence_length": 914,
+    "gc_content": 0.5063752276867031,
+    "protid": "ARAAL11545",
+    "id": 11172818
+  }, {
+    "taxon": {"strain": "", "species": "Arabis alpina"},
+    "xrefid": "A0A087GCD6",
+    "sequence_length": 863,
+    "gc_content": 0.4494598765432099,
+    "protid": "ARAAL19623",
+    "id": 11180896
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4DUS7",
+    "sequence_length": 884,
+    "gc_content": 0.4497175141242938,
+    "protid": "BRARP05324",
+    "id": 11189883
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4DW30",
+    "sequence_length": 921,
+    "gc_content": 0.48734634851771513,
+    "protid": "BRARP07608",
+    "id": 11192167
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4EK77",
+    "sequence_length": 910,
+    "gc_content": 0.46871569703622395,
+    "protid": "BRARP09804",
+    "id": 11194363
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4DRP8",
+    "sequence_length": 833,
+    "gc_content": 0.4272581934452438,
+    "protid": "BRARP13155",
+    "id": 11197714
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4DRP6",
+    "sequence_length": 833,
+    "gc_content": 0.43325339728217427,
+    "protid": "BRARP13157",
+    "id": 11197716
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4FB08",
+    "sequence_length": 874,
+    "gc_content": 0.44685714285714284,
+    "protid": "BRARP22320",
+    "id": 11206879
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4F8V8",
+    "sequence_length": 922,
+    "gc_content": 0.49404117009750814,
+    "protid": "BRARP23486",
+    "id": 11208045
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4EG51",
+    "sequence_length": 948,
+    "gc_content": 0.4457323498419389,
+    "protid": "BRARP32326",
+    "id": 11216885
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4ES80",
+    "sequence_length": 846,
+    "gc_content": 0.45218417945690675,
+    "protid": "BRARP36308",
+    "id": 11220867
+  }, {
+    "taxon": {"strain": "subsp. pekinensis", "species": "Brassica rapa "},
+    "xrefid": "M4CYG9",
+    "sequence_length": 902,
+    "gc_content": 0.4654854189737911,
+    "protid": "BRARP39233",
+    "id": 11223792
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078FBG6",
+    "sequence_length": 884,
+    "gc_content": 0.44896421845574386,
+    "protid": "BRANA04223",
+    "id": 11229807
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078HK01",
+    "sequence_length": 910,
+    "gc_content": 0.4679839004756678,
+    "protid": "BRANA08419",
+    "id": 11234003
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078FG99",
+    "sequence_length": 833,
+    "gc_content": 0.4272581934452438,
+    "protid": "BRANA11655",
+    "id": 11237239
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078FDR2",
+    "sequence_length": 816,
+    "gc_content": 0.4288045695634435,
+    "protid": "BRANA11656",
+    "id": 11237240
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 844,
+    "gc_content": 0.39487179487179486,
+    "protid": "BRANA21147",
+    "id": 11246731
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 922,
+    "gc_content": 0.49404117009750814,
+    "protid": "BRANA22314",
+    "id": 11247898
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078HK12",
+    "sequence_length": 943,
+    "gc_content": 0.4417372881355932,
+    "protid": "BRANA31283",
+    "id": 11256867
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 816,
+    "gc_content": 0.45777233782129745,
+    "protid": "BRANA34811",
+    "id": 11260395
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 886,
+    "gc_content": 0.4637354378053363,
+    "protid": "BRANA37953",
+    "id": 11263537
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078I9S8",
+    "sequence_length": 921,
+    "gc_content": 0.4880694143167028,
+    "protid": "BRANA39392",
+    "id": 11264976
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078HE96",
+    "sequence_length": 899,
+    "gc_content": 0.48333333333333334,
+    "protid": "BRANA50742",
+    "id": 11276326
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 857,
+    "gc_content": 0.4491064491064491,
+    "protid": "BRANA52087",
+    "id": 11277671
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078H5B7",
+    "sequence_length": 910,
+    "gc_content": 0.4716428832784486,
+    "protid": "BRANA53377",
+    "id": 11278961
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 922,
+    "gc_content": 0.48934633441675696,
+    "protid": "BRANA77069",
+    "id": 11302653
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 756,
+    "gc_content": 0.4178775869660942,
+    "protid": "BRANA78346",
+    "id": 11303930
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078GBC3",
+    "sequence_length": 576,
+    "gc_content": 0.44020797227036396,
+    "protid": "BRANA83758",
+    "id": 11309342
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "A0A078F5G7",
+    "sequence_length": 944,
+    "gc_content": 0.44479717813051145,
+    "protid": "BRANA85721",
+    "id": 11311305
+  }, {
+    "taxon": {"strain": "", "species": "Brassica napus"},
+    "xrefid": "",
+    "sequence_length": 908,
+    "gc_content": 0.4660799413274661,
+    "protid": "BRANA89251",
+    "id": 11314835
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3AKU3",
+    "sequence_length": 884,
+    "gc_content": 0.45160075329566857,
+    "protid": "BRAOL06520",
+    "id": 11330234
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3AWR8",
+    "sequence_length": 983,
+    "gc_content": 0.4698509485094851,
+    "protid": "BRAOL10282",
+    "id": 11333996
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3B048",
+    "sequence_length": 870,
+    "gc_content": 0.4489092996555683,
+    "protid": "BRAOL11386",
+    "id": 11335100
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3B412",
+    "sequence_length": 910,
+    "gc_content": 0.47054518843761434,
+    "protid": "BRAOL12733",
+    "id": 11336447
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3BHE5",
+    "sequence_length": 878,
+    "gc_content": 0.4467197572999621,
+    "protid": "BRAOL17320",
+    "id": 11341034
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3DBP0",
+    "sequence_length": 922,
+    "gc_content": 0.48934633441675696,
+    "protid": "BRAOL39499",
+    "id": 11363213
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3DFZ8",
+    "sequence_length": 619,
+    "gc_content": 0.42849462365591395,
+    "protid": "BRAOL40984",
+    "id": 11364698
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3DYB9",
+    "sequence_length": 604,
+    "gc_content": 0.44573002754820934,
+    "protid": "BRAOL46974",
+    "id": 11370688
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3E4D4",
+    "sequence_length": 948,
+    "gc_content": 0.4450298559887601,
+    "protid": "BRAOL49063",
+    "id": 11372777
+  }, {
+    "taxon": {"strain": "", "species": "Brassica oleracea"},
+    "xrefid": "A0A0D3EH50",
+    "sequence_length": 908,
+    "gc_content": 0.4671800513384672,
+    "protid": "BRAOL53467",
+    "id": 11377181
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 754,
+    "gc_content": 0.44194260485651216,
+    "protid": "ARALY00872",
+    "id": 11382406
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 941,
+    "gc_content": 0.4150743099787686,
+    "protid": "ARALY05478",
+    "id": 11387012
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 912,
+    "gc_content": 0.4421321650237313,
+    "protid": "ARALY17646",
+    "id": 11399180
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 897,
+    "gc_content": 0.4446919079435783,
+    "protid": "ARALY20422",
+    "id": 11401956
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 860,
+    "gc_content": 0.451413085559427,
+    "protid": "ARALY25592",
+    "id": 11407126
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 630,
+    "gc_content": 0.41627047015319596,
+    "protid": "ARALY28925",
+    "id": 11410459
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 920,
+    "gc_content": 0.48389431777053926,
+    "protid": "ARALY28998",
+    "id": 11410532
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 906,
+    "gc_content": 0.45130466740169056,
+    "protid": "ARALY29529",
+    "id": 11411063
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 886,
+    "gc_content": 0.44682450206689217,
+    "protid": "ARALY30623",
+    "id": 11412157
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis lyrata"},
+    "xrefid": "",
+    "sequence_length": 517,
+    "gc_content": 0.41763191763191765,
+    "protid": "ARALY31726",
+    "id": 11413260
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHG_ARATH",
+    "sequence_length": 849,
+    "gc_content": 0.44392156862745097,
+    "protid": "ARATH02672",
+    "id": 11416873
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHJ_ARATH",
+    "sequence_length": 912,
+    "gc_content": 0.4428623585250091,
+    "protid": "ARATH12172",
+    "id": 11426373
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHA_ARATH",
+    "sequence_length": 902,
+    "gc_content": 0.4481358434846807,
+    "protid": "ARATH14735",
+    "id": 11428936
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHD_ARATH",
+    "sequence_length": 921,
+    "gc_content": 0.4812002892263196,
+    "protid": "ARATH18241",
+    "id": 11432442
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHC_ARATH",
+    "sequence_length": 905,
+    "gc_content": 0.4429727740986019,
+    "protid": "ARATH18582",
+    "id": 11432783
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHH_ARATH",
+    "sequence_length": 886,
+    "gc_content": 0.447576099210823,
+    "protid": "ARATH19554",
+    "id": 11433755
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHB_ARATH",
+    "sequence_length": 843,
+    "gc_content": 0.44352290679304895,
+    "protid": "ARATH21236",
+    "id": 11435437
+  }, {
+    "taxon": {"strain": "", "species": "Arabidopsis thaliana"},
+    "xrefid": "RBOHF_ARATH",
+    "sequence_length": 944,
+    "gc_content": 0.4105820105820106,
+    "protid": "ARATH25714",
+    "id": 11439915
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061FX15",
+    "sequence_length": 786,
+    "gc_content": 0.43244387971198645,
+    "protid": "THECC10764",
+    "id": 11452454
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061FZQ1",
+    "sequence_length": 910,
+    "gc_content": 0.4621295279912184,
+    "protid": "THECC11172",
+    "id": 11452862
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061G6P2",
+    "sequence_length": 932,
+    "gc_content": 0.4608788853161844,
+    "protid": "THECC12558",
+    "id": 11454248
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061FAG0",
+    "sequence_length": 889,
+    "gc_content": 0.4786516853932584,
+    "protid": "THECC19230",
+    "id": 11460920
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061FJU4",
+    "sequence_length": 961,
+    "gc_content": 0.47193347193347196,
+    "protid": "THECC23969",
+    "id": 11465659
+  }, {
+    "taxon": {"strain": "", "species": "Theobroma cacao"},
+    "xrefid": "A0A061GXU2",
+    "sequence_length": 911,
+    "gc_content": 0.4283625730994152,
+    "protid": "THECC29078",
+    "id": 11470768
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 857,
+    "gc_content": 0.44871794871794873,
+    "protid": "GOSHI00921",
+    "id": 11472257
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 904,
+    "gc_content": 0.4294659300184162,
+    "protid": "GOSHI04073",
+    "id": 11475409
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 721,
+    "gc_content": 0.4519852262234534,
+    "protid": "GOSHI08363",
+    "id": 11479699
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 849,
+    "gc_content": 0.4717647058823529,
+    "protid": "GOSHI08892",
+    "id": 11480228
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 907,
+    "gc_content": 0.4280469897209985,
+    "protid": "GOSHI12406",
+    "id": 11483742
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 841,
+    "gc_content": 0.42280285035629456,
+    "protid": "GOSHI12849",
+    "id": 11484185
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 751,
+    "gc_content": 0.4432624113475177,
+    "protid": "GOSHI15050",
+    "id": 11486386
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 884,
+    "gc_content": 0.45084745762711864,
+    "protid": "GOSHI22924",
+    "id": 11494260
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 918,
+    "gc_content": 0.44541167936162496,
+    "protid": "GOSHI25161",
+    "id": 11496497
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 940,
+    "gc_content": 0.4410201912858661,
+    "protid": "GOSHI28852",
+    "id": 11500188
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 929,
+    "gc_content": 0.4444444444444444,
+    "protid": "GOSHI33134",
+    "id": 11504470
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 919,
+    "gc_content": 0.4340579710144927,
+    "protid": "GOSHI33500",
+    "id": 11504836
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 913,
+    "gc_content": 0.4576951130561634,
+    "protid": "GOSHI37818",
+    "id": 11509154
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 932,
+    "gc_content": 0.46195069667738475,
+    "protid": "GOSHI38416",
+    "id": 11509752
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "A0A1U8NZQ1",
+    "sequence_length": 907,
+    "gc_content": 0.42841409691629956,
+    "protid": "GOSHI42355",
+    "id": 11513691
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 841,
+    "gc_content": 0.42161520190023755,
+    "protid": "GOSHI42813",
+    "id": 11514149
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 922,
+    "gc_content": 0.4539544962080173,
+    "protid": "GOSHI45447",
+    "id": 11516783
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 884,
+    "gc_content": 0.4500941619585687,
+    "protid": "GOSHI54276",
+    "id": 11525612
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 802,
+    "gc_content": 0.4292237442922374,
+    "protid": "GOSHI56637",
+    "id": 11527973
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 918,
+    "gc_content": 0.44541167936162496,
+    "protid": "GOSHI56759",
+    "id": 11528095
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 803,
+    "gc_content": 0.4320066334991708,
+    "protid": "GOSHI63044",
+    "id": 11534380
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 929,
+    "gc_content": 0.44695340501792113,
+    "protid": "GOSHI63062",
+    "id": 11534398
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 930,
+    "gc_content": 0.44360902255639095,
+    "protid": "GOSHI64287",
+    "id": 11535623
+  }, {
+    "taxon": {"strain": "", "species": "Gossypium hirsutum"},
+    "xrefid": "",
+    "sequence_length": 928,
+    "gc_content": 0.44599928238249015,
+    "protid": "GOSHI65250",
+    "id": 11536586
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "D7SKP3",
+    "sequence_length": 852,
+    "gc_content": 0.44509574052364204,
+    "protid": "VITVI08382",
+    "id": 11546685
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "E0CSL2",
+    "sequence_length": 840,
+    "gc_content": 0.4827586206896552,
+    "protid": "VITVI10666",
+    "id": 11548969
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "",
+    "sequence_length": 873,
+    "gc_content": 0.492372234935164,
+    "protid": "VITVI18854",
+    "id": 11557157
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "",
+    "sequence_length": 827,
+    "gc_content": 0.47906602254428343,
+    "protid": "VITVI19450",
+    "id": 11557753
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "",
+    "sequence_length": 906,
+    "gc_content": 0.47519294377067256,
+    "protid": "VITVI19451",
+    "id": 11557754
+  }, {
+    "taxon": {"strain": "", "species": "Vitis vinifera"},
+    "xrefid": "",
+    "sequence_length": 922,
+    "gc_content": 0.48392921632358255,
+    "protid": "VITVI23171",
+    "id": 11561474
+  }, {
+    "taxon": {"strain": "", "species": "Amborella trichopoda"},
+    "xrefid": "U5DF75",
+    "sequence_length": 857,
+    "gc_content": 0.4506604506604507,
+    "protid": "AMBTC09941",
+    "id": 11574451
+  }, {
+    "taxon": {"strain": "", "species": "Amborella trichopoda"},
+    "xrefid": "W1PFH7",
+    "sequence_length": 613,
+    "gc_content": 0.43051031487513575,
+    "protid": "AMBTC12008",
+    "id": 11576518
+  }, {
+    "taxon": {"strain": "", "species": "Amborella trichopoda"},
+    "xrefid": "W1NIQ4",
+    "sequence_length": 862,
+    "gc_content": 0.4426419466975666,
+    "protid": "AMBTC19212",
+    "id": 11583722
+  }, {
+    "taxon": {"strain": "", "species": "Amborella trichopoda"},
+    "xrefid": "W1P925",
+    "sequence_length": 917,
+    "gc_content": 0.5010893246187363,
+    "protid": "AMBTC22043",
+    "id": 11586553
+  }, {
+    "taxon": {"strain": "", "species": "Amborella trichopoda"},
+    "xrefid": "W1P7B1",
+    "sequence_length": 896,
+    "gc_content": 0.4672862453531598,
+    "protid": "AMBTC24402",
+    "id": 11588912
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8TAD6",
+    "sequence_length": 902,
+    "gc_content": 0.5795496493170912,
+    "protid": "SELML02071",
+    "id": 11593852
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8T2H8",
+    "sequence_length": 645,
+    "gc_content": 0.4917440660474716,
+    "protid": "SELML04398",
+    "id": 11596179
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SZQ4",
+    "sequence_length": 710,
+    "gc_content": 0.49507735583684953,
+    "protid": "SELML05254",
+    "id": 11597035
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SYS3",
+    "sequence_length": 811,
+    "gc_content": 0.5287356321839081,
+    "protid": "SELML05812",
+    "id": 11597593
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SW62",
+    "sequence_length": 819,
+    "gc_content": 0.4898373983739837,
+    "protid": "SELML06479",
+    "id": 11598260
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SWI6",
+    "sequence_length": 819,
+    "gc_content": 0.49105691056910566,
+    "protid": "SELML06595",
+    "id": 11598376
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SQQ5",
+    "sequence_length": 902,
+    "gc_content": 0.5267626430417128,
+    "protid": "SELML08301",
+    "id": 11600082
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SPF0",
+    "sequence_length": 796,
+    "gc_content": 0.4997908824759515,
+    "protid": "SELML08734",
+    "id": 11600515
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8SFH9",
+    "sequence_length": 876,
+    "gc_content": 0.5302166476624858,
+    "protid": "SELML11760",
+    "id": 11603541
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8S6L0",
+    "sequence_length": 810,
+    "gc_content": 0.5244554048499794,
+    "protid": "SELML14433",
+    "id": 11606214
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8RTB2",
+    "sequence_length": 901,
+    "gc_content": 0.5262379896526238,
+    "protid": "SELML18555",
+    "id": 11610336
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8RMU6",
+    "sequence_length": 895,
+    "gc_content": 0.5773809523809523,
+    "protid": "SELML20354",
+    "id": 11612135
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8RJQ8",
+    "sequence_length": 813,
+    "gc_content": 0.4905814905814906,
+    "protid": "SELML22112",
+    "id": 11613893
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8RJR0",
+    "sequence_length": 913,
+    "gc_content": 0.49927060539752005,
+    "protid": "SELML22114",
+    "id": 11613895
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8RFZ6",
+    "sequence_length": 885,
+    "gc_content": 0.5060195635816404,
+    "protid": "SELML23272",
+    "id": 11615053
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8R7W0",
+    "sequence_length": 756,
+    "gc_content": 0.5398502862175253,
+    "protid": "SELML25789",
+    "id": 11617570
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8R5H8",
+    "sequence_length": 867,
+    "gc_content": 0.5284178187403994,
+    "protid": "SELML26145",
+    "id": 11617926
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8R078",
+    "sequence_length": 715,
+    "gc_content": 0.4925512104283054,
+    "protid": "SELML28721",
+    "id": 11620502
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8QTW7",
+    "sequence_length": 883,
+    "gc_content": 0.4984917043740573,
+    "protid": "SELML30673",
+    "id": 11622454
+  }, {
+    "taxon": {"strain": "", "species": "Selaginella moellendorffii"},
+    "xrefid": "D8QR25",
+    "sequence_length": 711,
+    "gc_content": 0.5280898876404494,
+    "protid": "SELML32056",
+    "id": 11623837
+  }]
+};

--- a/examples/easy_embedding/example.js
+++ b/examples/easy_embedding/example.js
@@ -1,0 +1,110 @@
+(
+  function (div) {
+    var theme = iHam()
+      .on('node_selected', function (node) {
+        d3.select('#current-node')
+          .text(node.node_name());
+      })
+      .query_gene({
+        id: 12
+      })
+        .show_oma_link(false)
+      .orthoxml(data.orthoxml)
+      .newick(data.tree)
+      .fam_data(data.fam_data)
+      .tree_width(330)
+      .board_width(530)
+      .query_gene({id: 3965})
+      .on("updating", function() {
+        d3.select("#updating")
+          .style("display", 'block');
+      })
+      .on("updated", function () {
+        d3.select("#updating")
+          .style("display", "none");
+      })
+      .on("hogs_removed", function (what) {
+        if (what.length) {
+          d3.select(".alert_remove")
+            .style("display", "block")
+        } else {
+          d3.select(".alert_remove")
+            .style("display", "none");
+        }
+      });
+
+    theme(div);
+
+    // Update the color schemas
+    d3.select("#color-schema-dropdown")
+      .selectAll("a")
+      .on("click", function () {
+        // Manage state of menu itself
+        d3.select(this.parentNode).selectAll("a").classed("active", false);
+        d3.select(this)
+          .classed("active", true);
+
+        if (d3.select(this).text() === "Query Gene") {
+          theme.gene_colors(function (d) {
+            return (d.id === 3965 ? "#27ae60" : "#95a5a6");
+          });
+        }
+
+        if (d3.select(this).text() === "Gene Length") {
+          var data = theme.fam_data();
+          var domain = d3.extent(data, function (d) {
+            return d.sequence_length
+          });
+          var colorScale = d3.scale.linear()
+            .domain(domain)
+            .range(["red", "blue"]);
+          theme.gene_colors(function (d) {
+            return colorScale(d.gene.sequence_length);
+          });
+        }
+
+        if (d3.select(this).text() === "GC Content") {
+          var data = theme.fam_data();
+          var domain = d3.extent(data, function (d) {
+            return d.gc_content
+          });
+          var colorScale = d3.scale.linear()
+            .domain(domain)
+            .range(["red", "blue"]);
+          theme.gene_colors(function (d) {
+            return colorScale(d.gene.gc_content);
+          });
+        }
+      });
+
+    // Update event for gene tooltips
+    d3.select("#gene-tooltips-dropdown")
+      .selectAll("a")
+      .on("click", function () {
+        // Manage state of menu itself
+        d3.select(this.parentNode).selectAll("a").classed("active", false);
+        d3.select(this)
+          .classed("active", true);
+
+        if (d3.select(this).text() === "Click") {
+          theme.gene_tooltips_on("click");
+        }
+        if (d3.select(this).text() === "Mouseover") {
+          theme.gene_tooltips_on("mouseover");
+        }
+      });
+
+    // Set minimum species coverage
+    d3.select("#percentage-coverage-selector").select("input")
+      .on("input", function () {
+        theme.coverage_threshold(d3.select(this).property("value"));
+      });
+
+    // Reset the coverage
+    d3.select("#reset_column_filter")
+      .on("click", function () {
+        d3.select("#percentage-coverage-selector").select("input").property("value", 0);
+        theme.coverage_threshold(0);
+      })
+  }
+)(document.getElementById('iham'));

--- a/examples/easy_embedding/index.html
+++ b/examples/easy_embedding/index.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test</title>
+
+    <!-- d3 -->
+    <script src="https://d3js.org/d3.v3.js"></script>
+
+    <!-- TnT -->
+    <link rel="stylesheet" href="http://tntvis.github.io/tnt/build/tnt.css" type="text/css"/>
+    <script src="http://tntvis.github.io/tnt/build/tnt.js" charset="utf-8"></script>
+
+    <!-- TnT Tooltip-->
+    <link rel="stylesheet" href="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.css" type="text/css"/>
+    <script src="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.min.js" charset="utf-8"></script>
+
+    <!-- iHam javascript & css -->
+    <script src="https://dessimozlab.github.io/iHam/iHam.js"></script>
+    <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" type="text/css"/>
+
+    <script src="./data.js"></script>
+
+
+    <!-- Bootstrap CDN for layout styles -->
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"
+          integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+    <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js"
+            integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo"
+            crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.0/umd/popper.min.js"
+            integrity="sha384-cs/chFZiN24E4KMATLdqdvsezGxaGsi4hLGOzlXwp5UZB1LY//20VyM2taTB4QvJ"
+            crossorigin="anonymous"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"
+            integrity="sha384-uefMccjFJAIv6A+rW+L4AHf99KvxDjWSu1z9VI8SKNVmz4sk7buKt/6v9KI65qnm"
+            crossorigin="anonymous"></script>
+
+    <!-- Roboto font -->
+    <link href="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
+
+
+    <style>
+        body {
+            font-family: 'Roboto', sans-serif;
+        }
+
+        #updating {
+            position: absolute;
+            left: 20px;
+            display: none;
+        }
+
+        .alert_remove {
+            margin-bottom: 0px;
+            padding: 4px;
+            display: none;
+        }
+
+        .alert-link {
+            cursor: pointer;
+        }
+
+        #header {
+            margin-left: 20px;
+            margin-bottom: 20px;
+        }
+
+        #header > h3 {
+            margin-top: 20px;
+            margin-bottom: 20px;
+        }
+        #menu-bar > div {
+            display: inline-block;
+        }
+
+        .dropdown-toggle {
+            padding-top: 7px;
+            padding-bottom: 7px;
+        }
+
+    </style>
+</head>
+<body>
+
+<div id="header">
+    <h3>Hierarchical group HOG:0000474 open at level of <span id="current-node"></span></h3>
+
+    <div id="menu-bar">
+        <div id="color-schema-dropdown" class="dropdown">
+            <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" id="dropdownMenuButton"
+                    data-toggle="dropdown"
+                    aria-haspopup="true" aria-expanded="false">
+                Set color scheme
+            </button>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                <a class="dropdown-item active" href="#">Query Gene</a>
+                <a class="dropdown-item" href="#">Gene Length</a>
+                <a class="dropdown-item" href="#">GC Content</a>
+            </div>
+        </div>
+
+        <div id="gene-tooltips-dropdown" class="dropdown">
+            <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-toggle="dropdown"
+                    aria-haspopup="true" aria-expanded="false">
+                Show gene tooltips on
+            </button>
+            <div class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                <a class="dropdown-item active" href="#">Click</a>
+                <a class="dropdown-item" href="#">Mouseover</a>
+            </div>
+        </div>
+
+        <div id="percentage-coverage-selector">
+            <button class="btn btn-sm btn-outline-dark" type="button"
+                    aria-haspopup="true" aria-expanded="false">Remove columns under <input id="set_min_coverage"
+                                                                                           type="number" step="10" value="0"
+                                                                                           min="0" max="100">% of species coverage
+            </button>
+        </div>
+    </div>
+</div>
+
+<div id="updating">
+    Updating...
+</div>
+
+<div class="alert alert-info text-center alert_remove"
+     role="alert"
+>
+    Lowly supported hogs have been removed as per settings.
+    <a class="alert-link" id="reset_column_filter">Click here to reset.</a>
+</div>
+
+
+<div style="width: 1500px; min-width: 500px;" id="iham"></div>
+
+<script src="./example.js"></script>
+</body>
+</html>

--- a/examples/top-bar/example.js
+++ b/examples/top-bar/example.js
@@ -8,6 +8,7 @@
       .query_gene({
         id: 12
       })
+        .show_oma_link(true)
       .orthoxml(data.orthoxml)
       .newick(data.tree)
       .fam_data(data.fam_data)

--- a/examples/top-bar/index.html
+++ b/examples/top-bar/index.html
@@ -29,8 +29,11 @@
     <link rel="stylesheet" href="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.css" type="text/css"/>
     <script src="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.min.js" charset="utf-8"></script>
 
-    <script src="https://dessimozlab.github.io/iHam/iHam.js"></script>
-    <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" type="text/css"/>
+    <!-- <script src="https://dessimozlab.github.io/iHam/iHam.js"></script>-->
+    <!-- <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" type="text/css"/>-->
+
+    <script src="../../build/iHam.js"></script>
+    <link rel="stylesheet" href="../../build/iHam.css" type="text/css"/>
 
     <script src="./data.js"></script>
 

--- a/examples/top-bar/index.html
+++ b/examples/top-bar/index.html
@@ -29,9 +29,6 @@
     <link rel="stylesheet" href="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.css" type="text/css"/>
     <script src="http://tntvis.github.io/tnt.tooltip/build/tnt.tooltip.min.js" charset="utf-8"></script>
 
-    <!-- <script src="https://dessimozlab.github.io/iHam/iHam.js"></script>-->
-    <!-- <link rel="stylesheet" href="https://dessimozlab.github.io/iHam/iHam.css" type="text/css"/>-->
-
     <script src="../../build/iHam.js"></script>
     <link rel="stylesheet" href="../../build/iHam.css" type="text/css"/>
 

--- a/src/iHam.js
+++ b/src/iHam.js
@@ -52,7 +52,7 @@ function iHam() {
 
     // Redirection url prefix for tooltip on genes
     // oma_info_url_template: '/cgi-bin/gateway.pl?f=DisplayEntry&amp;p1=',
-    show_oma_link: false, // clement - if not in oma, fasta/table links should be hidden.
+    show_oma_link: false,
 
     // text div id
     // current_level_id: 'current_level_text',
@@ -169,7 +169,7 @@ function iHam() {
         .text(node => {
           const limit = 30;
           const data = node.data();
-          if (node.is_collapsed()) { // clement - collapsed taxa display '[Collapsed taxa]' + 'name' now. 16 is length of '[Coll...]' prefix.
+          if (node.is_collapsed()) {
             if (data.name.length > limit - 16) {
               const truncName_col = data.name.substr(0, limit - 19) + "...";
               return `[Collapsed taxa] ${truncName_col.replace(/_/g, ' ')}`;
@@ -314,7 +314,7 @@ function iHam() {
           .add("hogs", hog_feature)
           .add('hog_groups', hog_group
             .on('click', function (hog) {
-              hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div, config.show_oma_link); //  clement - show_oma_link parameters
+              hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div, config.show_oma_link);
             })
           )
         )

--- a/src/iHam.js
+++ b/src/iHam.js
@@ -52,6 +52,7 @@ function iHam() {
 
     // Redirection url prefix for tooltip on genes
     // oma_info_url_template: '/cgi-bin/gateway.pl?f=DisplayEntry&amp;p1=',
+    show_oma_link: false, // clement - if not in oma, fasta/table links should be hidden.
 
     // text div id
     // current_level_id: 'current_level_text',
@@ -168,8 +169,12 @@ function iHam() {
         .text(node => {
           const limit = 30;
           const data = node.data();
-          if (node.is_collapsed()) {
-            return `[${node.n_hidden()} hidden taxa]`;
+          if (node.is_collapsed()) { // clement - collapsed taxa display '[Collapsed taxa]' + 'name' now. 16 is length of '[Coll...]' prefix.
+            if (data.name.length > limit - 16) {
+              const truncName_col = data.name.substr(0, limit - 19) + "...";
+              return `[Collapsed taxa] ${truncName_col.replace(/_/g, ' ')}`;
+            }
+            return `[Collapsed taxa] ${data.name}`;
           }
           if ((!config.show_internal_labels ||
             !state.highlight_condition(node)) &&
@@ -309,7 +314,7 @@ function iHam() {
           .add("hogs", hog_feature)
           .add('hog_groups', hog_group
             .on('click', function (hog) {
-              hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div);
+              hog_header_tooltip.display.call(this, hog, current_opened_taxa_name, div, config.show_oma_link); //  clement - show_oma_link parameters
             })
           )
         )

--- a/src/tooltips.js
+++ b/src/tooltips.js
@@ -115,7 +115,7 @@ module.exports = {
     close: () => _gene_tooltip.close()
   },
   hog_header_tooltip: {
-    display: function (hog, taxa_name, div) {
+    display: function (hog, taxa_name, div, show_oma_link) { //  clement - add option to display oma links
       const obj = {};
       obj.header = hog.name;
       obj.rows = [];
@@ -125,12 +125,16 @@ module.exports = {
       obj.rows.push({
         value: `% species represented: ${hog.coverage.toFixed(2)} %` // clement -  change coverage for % species represented
       });
-      obj.rows.push({
-        value: `<a href="https://omabrowser.org/oma/hogs/${hog.protid}/${taxa_name.replace(" ", "%20")}/fasta" target="_blank">Sequences (Fasta)</a>`,
-      });
-      obj.rows.push({
-        value: `<a href="https://omabrowser.org/oma/hogs/${hog.protid}/${taxa_name.replace(" ", "%20")}/" target="_blank">HOGs tables</a>`,
-      });
+      if (show_oma_link) {
+
+        obj.rows.push({
+          value: `<a href="https://omabrowser.org/oma/hogs/${hog.protid}/${taxa_name.replace(" ", "%20")}/fasta" target="_blank">Sequences (Fasta)</a>`,
+        });
+        obj.rows.push({
+          value: `<a href="https://omabrowser.org/oma/hogs/${hog.protid}/${taxa_name.replace(" ", "%20")}/" target="_blank">HOGs tables</a>`,
+        });
+
+      }
 
       _hog_header_tooltip = tooltip.list()
         .width(120)

--- a/src/tooltips.js
+++ b/src/tooltips.js
@@ -123,7 +123,7 @@ module.exports = {
         value: `Number of genes: ${hog.genes.length}`
       });
       obj.rows.push({
-        value: `Coverage: ${hog.coverage.toFixed(2)} %`
+        value: `% species represented: ${hog.coverage.toFixed(2)} %` // clement -  change coverage for % species represented
       });
       obj.rows.push({
         value: `<a href="https://omabrowser.org/oma/hogs/${hog.protid}/${taxa_name.replace(" ", "%20")}/fasta" target="_blank">Sequences (Fasta)</a>`,

--- a/src/tooltips.js
+++ b/src/tooltips.js
@@ -115,7 +115,7 @@ module.exports = {
     close: () => _gene_tooltip.close()
   },
   hog_header_tooltip: {
-    display: function (hog, taxa_name, div, show_oma_link) { //  clement - add option to display oma links
+    display: function (hog, taxa_name, div, show_oma_link) {
       const obj = {};
       obj.header = hog.name;
       obj.rows = [];
@@ -123,7 +123,7 @@ module.exports = {
         value: `Number of genes: ${hog.genes.length}`
       });
       obj.rows.push({
-        value: `% species represented: ${hog.coverage.toFixed(2)} %` // clement -  change coverage for % species represented
+        value: `% species represented: ${hog.coverage.toFixed(2)} %`
       });
       if (show_oma_link) {
 


### PR DESCRIPTION
- Replace coverage by “% species represented”,
- Display name of collapsed clades,
- Fasta,msa, hogs links in the hog table are displayed according to show_oma_link option.
